### PR TITLE
add frontend to compare between kidsle-data and overpass

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,15 @@ app.get('/', function(req, res) {
     res.send(content);
 });
 
+// CORS header securiy
+app.all('/*', function (req, res, next) {
+  res.header("Access-Control-Allow-Origin", "*");
+   res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
+  res.header("Access-Control-Allow-Headers", "X-Requested-With");
+  next();
+});
+
+/* playgrounds */
 app.use('/api/playgrounds', function (req, res, next) {
     let complete_path : string = resource_dir + pathSep() + 'playgrounds.geojson';
     fs.readFile(complete_path, 'utf8', function(err, data) {
@@ -37,6 +46,23 @@ app.use('/api/playgrounds', function (req, res, next) {
     });
 });
 
+app.use('/api/playgrounds_clean', function (req, res, next) {
+    let complete_path : string = resource_dir + pathSep() + 'playgrounds_clean.geojson';
+    fs.readFile(complete_path, 'utf8', function(err, data) {
+        if (err || data === 'undefined') data = '{}';
+        res.json(JSON.parse(data));
+    });
+});
+
+app.use('/api/playgrounds_kidsle_geojson', function (req, res, next) {
+    let complete_path : string = resource_dir + pathSep() + 'kidsle'+ pathSep() + 'playgrounds_kidsle_spreadsheet.geojson';
+    fs.readFile(complete_path, 'utf8', function(err, data) {
+        if (err || data === 'undefined') data = '{}';
+        res.json(JSON.parse(data));
+    });
+});
+
+/* doctors */
 app.use('/api/doctors', function (req, res, next) {
     let complete_path : string = resource_dir + pathSep() + 'doctors.geojson';
     fs.readFile(complete_path, 'utf8', function(err, data) {
@@ -45,6 +71,7 @@ app.use('/api/doctors', function (req, res, next) {
     });
 });
 
+/* schools */
 app.use('/api/schools', function (req, res, next) {
     let complete_path : string = resource_dir + pathSep() + 'schools.geojson';
     fs.readFile(complete_path, 'utf8', function(err, data) {

--- a/resources/kidsle/playgrounds_kidsle_spreadsheet.geojson
+++ b/resources/kidsle/playgrounds_kidsle_spreadsheet.geojson
@@ -1,0 +1,5495 @@
+{
+   "type": "FeatureCollection",
+   "features": [
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.41971803,51.32465755 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Probstheida,Südost",
+    "title":"Spielplatz Freundschaftspark",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Prager Straße/Russenstraße)','Bus: 79 (Haltestelle Prager Straße/Russenstraße)']",
+    "gaming_devices":"['Tischtennisplatte','Drehscheibe','Pendelmast']",
+    "equipment":"['Spielwiese','Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Prager Straße / Augustinerstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"Pascal"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4272528,51.3083876 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Probstheida,Südost",
+    "title":"Spielplatz Freundschaftspark- Rodelhügel';['Straßenbahn: 15 (Haltestelle Prager Straße/Russenstraße)','Bus: 79 (Haltestelle Prager Straße/Russenstraße)'];['Rodelhügel','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden'];Prager Straße / Augustinerstraße;51.3083876;12.4272528\nLeipzig;Probstheida,Südost;Spielplatz Freundschaftspark- Rodelhügel'",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Prager Straße/Russenstraße)','Bus: 79 (Haltestelle Prager Straße/Russenstraße)']",
+    "gaming_devices":"",
+    "equipment":"['Rodelhügel','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Prager Straße / Augustinerstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4645718,51.3076569 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Holzhausen,Südost",
+    "title":"Spielplatz An der Kirche",
+    "local_traffic":"['Bus: 74, 172 (Haltestelle Hauptstraße)']",
+    "gaming_devices":"['Seilkarussell','Kletter- und Rutschturm']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"An der Kirche / Hauptstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"Pascal"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.290554,51.315261 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Mitte,West",
+    "title":"Spielplatz Quartierspark Grünauer Welle",
+    "local_traffic":"['Straßenbahn: 1, 2 (Haltestelle Stuttgarter Allee)','Bus: 66 (Haltestelle Stuttgarter Allee)']",
+    "gaming_devices":"['3-er Reifenpendel']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"hinter der Schwimmhalle / Stuttgarter-Allee",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"Pascal"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.34383,51.35966 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Nordwest,Mitte",
+    "title":"Spielplatz Marienweg",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Stallbaumstraße)']",
+    "gaming_devices":"['Rutsch- und Kletterturm','Naturelemente']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze sind um das Rosental vorhanden']",
+    "address":"Marienweg / Hinterer Rosentalteich im Rosental",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.334455,51.316821 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Kleinzschocher,Südwest",
+    "title":"Spielplatz Volkspark Kleinzschocher – Ballspielplatz",
+    "local_traffic":"['Straßenbahn: 1, 2 (Haltestelle Rödelstraße)','Bus: 60, 74 (Haltestelle Rödelstraße)']",
+    "gaming_devices":"['Kletterpyramide','Rutsche','Seilstrecke','Streetballkorb','Tischtennisplatten','Torwände aus Stein']",
+    "equipment":"['Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"im Volkspark",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4699251,51.2711771 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Liebertwolkwitz,Südost",
+    "title":"Spielplatz Wiesengrund",
+    "local_traffic":"['Bus: 75 (Haltestelle Störmthaler Straße)']",
+    "gaming_devices":"['Doppelschaukel','Klettergerüst','Streetballkorb','Federelement']",
+    "equipment":"['Sandspielfläche','Spielwiese','Rodelhügel','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Wiesengrund / Am Grabenweg",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.405472,51.294519 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lößnig,Süd",
+    "title":"Spielplatz 'Rollerbahn' im Erholungspark Lößnig-Dölitz",
+    "local_traffic":"['Straßenbahn: 10, 16 (Haltestelle Lößnig)','Bus: 79 (Haltestelle Moritz-Hof)']",
+    "gaming_devices":"['Rollerbahn']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Zum Förderturm / im Park",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.401118,51.296411 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lößnig,Süd",
+    "title":"Spielplatz 'An der Schäferei' im Erholungspark Lößnig-Dölitz",
+    "local_traffic":"['Straßenbahn: 10, 16 (Haltestelle Lößnig)','Bus: 79 (Haltestelle Moritz-Hof)']",
+    "gaming_devices":"['Holzkarren','Schäfer und Schafe']",
+    "equipment":"['Spielwiese','Bänke','Findlinge','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Siegfriedstraße / im Park",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.401811,51.297437 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lößnig,Süd",
+    "title":"Spielplatz 'Tischtennisplatz' im Erholungspark Lößnig-Dölitz",
+    "local_traffic":"['Straßenbahn: 10, 16 (Haltestelle Lößnig)','Bus: 79 (Haltestelle Moritz-Hof)']",
+    "gaming_devices":"['Tischtennisplatten']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"nördlich der Siegfriedstaße / im Park",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.40466,51.297692 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lößnig,Süd",
+    "title":"Spielplatz 'Fröbelplatz' im Erholungspark Lößnig-Dölitz",
+    "local_traffic":"['Straßenbahn: 10, 16 (Haltestelle Lößnig)','Bus: 79 (Haltestelle Moritz-Hof)']",
+    "gaming_devices":"['Kletterwürfel','Seilzug','Balancierhölzer']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Siegfriedstraße / im Park",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.405846,51.298127 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lößnig,Süd",
+    "title":"Spielplatz 'Kletterplatz' im Erholungspark Lößnig-Dölitz",
+    "local_traffic":"['Straßenbahn: 10, 16 (Haltestelle Lößnig)','Bus: 79 (Haltestelle Moritz-Hof)']",
+    "gaming_devices":"['Kletterturm mit Rutsche','Seilgerüst','Hängematte','Kletterwand','Doppelschaukel']",
+    "equipment":"['Rollstuhlzugang','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"nördlich der Siegfriedstraße / im Park",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.40599,51.298487 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lößnig,Süd",
+    "title":"Spielplatz 'Kugelplatz' im Erholungspark Lößnig-Dölitz",
+    "local_traffic":"['Straßenbahn: 10, 16 (Haltestelle Lößnig)','Bus: 79 (Haltestelle Moritz-Hof)']",
+    "gaming_devices":"['Kletterkugeln']",
+    "equipment":"['Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"nördlich der Siegfriedstraße / im Park",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4007584,51.2998336 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lößnig,Süd",
+    "title":"Spielplatz Willi-Bredel-Straße",
+    "local_traffic":"['Straßenbahn: 10, 16 (Haltestelle Lößnig)','Bus: 79 (Haltestelle Moritz-Hof)']",
+    "gaming_devices":"['Streetballkorb','Tischtennis']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Willi-Bredel-Straße / Hans-Marchwitza-Straße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.265636,51.30361 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lausen-Grünau,West",
+    "title":"Spielplatz Zschochersche Allee",
+    "local_traffic":"['Straßenbahn: 1 (Haltestelle Zschampertaue)','Bus: 61, 66, 80E, 161 (Haltestelle Zschampertaue)']",
+    "gaming_devices":"['Seilbahn','Rutschen','Doppelschaukel','Wipptiere','Holzhäuser','Pendel','Wackelfloß','Balancierschiff']",
+    "equipment":"['Schattenplätze','Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Zschochersche Allee",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3773369,51.3059788 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Süd,Connewitz",
+    "title":"Spielplatz Leopoldstraße",
+    "local_traffic":"['Bus Linie 107 (Haltestelle Mathildenstraße)','Straßenbahn Linie 9 (Haltestelle Mathildenstraße)']",
+    "gaming_devices":"['Tischtennisplatten']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze sind vorhanden']",
+    "address":"Leopoldstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.455971,51.312981 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Holzhausen,Südost",
+    "title":"Spielplatz Walter-Markov-Ring",
+    "local_traffic":"['Bus: 74, 172 (Haltestelle Sophienhöhe)']",
+    "gaming_devices":"['Balancierrolle','Pendelmast','Federteller','Doppelschaukel']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Walter-Markov-Ring / Höhe Maienweg",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.290525,51.315259 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Mitte,West",
+    "title":"Spielplatz Stuttgarter Allee",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Schönauer Ring)','Bus: 61, 65, 66, 80E, 161 (Haltestelle Schönauer Ring)']",
+    "gaming_devices":"['Rutschkugel','Rutschstangen']",
+    "equipment":"['Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Stuttgarter Allee ",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.288602,51.325698 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"West,Schönau",
+    "title":"Spielplatz Garskestraße",
+    "local_traffic":"['Bus Linie 65, 80E, 61, 66, 161 (Haltestelle Schönauer Ring)','Straßenbahn Linie 8, 15 (Haltestelle Schönauer Ring)']",
+    "gaming_devices":"",
+    "equipment":"['Sandspielfläche','Bänke','Parkmöglichkeit:','öffentliche Parkplätze sind vorhanden']",
+    "address":"Garskestraße/ Stuttgarter Allee",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.2704691,51.3191831 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Nord,West",
+    "title":"Spielplatz Zum Rodelhügel",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Plovdiver Straße)','Bus: 62, 65, 66 (Haltestelle Plovdiver Straße)']",
+    "gaming_devices":"",
+    "equipment":"['Rodelhügel','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Andromedaweg",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.377459,51.309897 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Connewitz,Süd",
+    "title":"Spielplatz Wiedebachplatz",
+    "local_traffic":"['Straßenbahn: 10 (Haltestelle Wiedebachplatz)']",
+    "gaming_devices":"['Kletterwand','Rutschturm','Schaukel','Drehschüssel']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Wiedebachstraße/Bernhard-Göring-Straße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.275243,51.319262 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Nord,West",
+    "title":"Spielplatz Titaniaweg",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Kiewer Straße)','Bus: 62, 65, 66 (Haltestelle Kiewer Straße)']",
+    "gaming_devices":"['Kletterturm','Rutsche']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Titaniaweg",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4190271,51.3211187 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Weißeplatz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Weißestraße)']",
+    "gaming_devices":"['Rutschhalbkugel']",
+    "equipment":"['Schattenplätze','Bänke','Sandspielfläche','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Weißestraße / Arnoldstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.411601,51.321551 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Thonberger Park",
+    "local_traffic":"['Straßenbahn: 2, 15 (Haltestelle Naunhofer Straße)','Bus: 70, 74 (Haltestelle Naunhofer Straße)']",
+    "gaming_devices":"['Tischtennisplatte','Fußballtore','Drehscheibe','Holzkletterhaus']",
+    "equipment":"['Sandspielfläche','Spielwiese','Findlinge','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Lichtenbergweg / Güntzstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.2717667,51.3230753 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Nord,West",
+    "title":"Spielplatz Uranuspark",
+    "local_traffic":"['Bus: 62, 66 (Haltestelle Uranusstraße)']",
+    "gaming_devices":"['Tischtennisplatten','Streetballkorb']",
+    "equipment":"['Jugendsitzbereich','Bänke','Schattenplätze','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Uranusstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.392638,51.3251476 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Südost,Mitte",
+    "title":"Spielplatz Tischtennisplatz im Friedenspark",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Straßenbahn: 2, 16 (Haltestelle Deutsche Nationalbibliothek)','Bus: 60 (Haltestelle Ostplatz)','Bus: 74 (Haltestelle Deutsche Nationalbibliothek)']",
+    "gaming_devices":"['Tischtennisplatten']",
+    "equipment":"['Schatten','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Linnéstraße / Phillip-Rosenthal-Straße",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.392638,51.3251476 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Südost,Mitte",
+    "title":"Spielplatz Volleyball- und Fitnessplatz im Friedenspark",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Straßenbahn: 2, 16 (Haltestelle Deutsche Nationalbibliothek)','Bus: 60 (Haltestelle Ostplatz)','Bus: 74 (Haltestelle Deutsche Nationalbibliothek)']",
+    "gaming_devices":"['Volleyballfeld','Fitnessgeräte','Bouleplatz']",
+    "equipment":"['Spielplatz','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Linnéstraße / Phillip-Rosenthal-Straße",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.324248,51.327291 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Südwest,Plagwitz",
+    "title":"Spielplatz Plagwitzer Bahnhof",
+    "local_traffic":"['Straßenbahn Linie 14 (Haltestelle S-Bahnhof Plagwitz) ','Bus Linie 60 (Haltestelle Naumburger Straße)']",
+    "gaming_devices":"['Schaukel','Luftschaukel','Klettersteine']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze sind vorhanden']",
+    "address":"Naumburger Straße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.422109,51.317151 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Thiemstraße",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Rathaus Stötteritz)','Bus: 74 (Haltestelle Rathaus Stötteritz)','Bus: 79 (Haltestelle Schwimmhalle Südost)']",
+    "gaming_devices":"['Kletternetz','Drehscheibe','Kletter- und Rutschhaus','Balancierseile','Reifenschaukel']",
+    "equipment":"['Schattenplätze','Spielwiese','Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Thiemstraße / Václac-Neumann-Straße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.432656,51.334995 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Anger-Crottendorf,Ost",
+    "title":"Spielplatz Volkshain Stünz",
+    "local_traffic":"['Bus: 77 (Haltestelle Stünz)']",
+    "gaming_devices":"",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Pflaumenallee / Borngasse",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4763541,51.3393006 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Topasstraße",
+    "local_traffic":"['Bus: 172 (Haltestelle Opalstraße)']",
+    "gaming_devices":"['Wipptier','Klettergerüst','Wippe','Kletterholz']",
+    "equipment":"['Spielwiese','Bänke',' ','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Topasstraße (Richtung Hans-Weigel-Straße)",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4763541,51.3393006 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Topasstraße",
+    "local_traffic":"['Bus: 172 (Haltestelle Opalstraße)']",
+    "gaming_devices":"['Wipptier','Klettergerüst','Wippe','Kletterholz']",
+    "equipment":"['Spielwiese','änke',' ','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Topasstraße (Richtung Hans-Weigel-Straße)",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.483689,51.339442 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Verdistraße",
+    "local_traffic":"['Bus: 172 (Haltestelle Opalstraße)']",
+    "gaming_devices":"['Kletterturm','Rutsche']",
+    "equipment":"['Sandspielfläche','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Verdistraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Connewitz,Süd",
+    "title":"Spielplatz Teichstraße",
+    "local_traffic":"['Straßenbahn: 9 (Haltestelle Mathildenstraße)','Bus: 107 (Haltestelle Mathildenstraße)']",
+    "gaming_devices":"['Rutsche','Pendelkreuz','Sitzkarussell','Holzklettergerüst']",
+    "equipment":"['Sitzgruppe','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Teichstraße/Zugang Mühlholz ",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.32894,51.315545 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Kleinzschocher,Südwest",
+    "title":"Spielplatz Volkspark Kleinzschocher – Holzspielplatz",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Schwartzestraße)']",
+    "gaming_devices":"['Holzkrokodil','Wipptiere','Steintier']",
+    "equipment":"['Schattenplätze','Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"am Eingang zum Park",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Nordwest,Mitte",
+    "title":"Spielplatz Vorderes Rosental",
+    "local_traffic":"['Straßenbahn: 12 (Haltestelle Am Zoo)']",
+    "gaming_devices":"['Steintiere']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Emil-Fuchs-Straße / Rückseite Zoo",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Leutzsch,Alt-West",
+    "title":"Spielplatz Waldluft",
+    "local_traffic":"['Bus: 67 (Haltestelle Mathiesenstraße)']",
+    "gaming_devices":"['Doppelschaukel','Klettergerüst','Balancierbalken','Gewichtheber','Holzsitzgruppe']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','Hinweis:','Die öffentlichen Parkplätze befinden sich außerhalb des Forstgebietes.']",
+    "address":"Am KGV Waldluft/ im Forst",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Leutzsch,Alt-West",
+    "title":"Spielplatz Wilder Mann",
+    "local_traffic":"['Bus: 67 (Haltestelle Mathiesenstraße), 80 (Haltestelle Am Sportpark)']",
+    "gaming_devices":"['Balanciersteg','Pendel','Holzkletterdach']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','Hinweis:','Die öffentlichen Parkplätze befinden sich außerhalb des Forstgebietes.']",
+    "address":"direkt im Forstgebiet Wilder Mann",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Connewitz,Süd",
+    "title":"Spielplatz Wildpark - Linienkreuz",
+    "local_traffic":"['Straßenbahn: 9 (HaltestelleWildpark)','Bus: 107 (Haltestelle Wildpark)']",
+    "gaming_devices":"['Laufrolle','Reck']",
+    "equipment":"['Holztisch mit Holzsitzen','Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Kreuzung Die Neue Linieim Wildpark",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Connewitz,Süd",
+    "title":"Spielplatz Wildpark - Teehaus",
+    "local_traffic":"['Straßenbahn: 9 (Haltestelle Wildpark)','Bus: 107 (Haltestelle Wildpark)']",
+    "gaming_devices":"['Rutschturm','Karussell','Wippen','Schaukeln','Klettersprossen']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Koburger Straße / im Wildpark",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Connewitz,Süd",
+    "title":"Spielplatz Wildpark – Märchenspielplatz",
+    "local_traffic":"['Straßenbahn: 9 (Wildpark)','Bus: 107 (Wildpark)']",
+    "gaming_devices":"['Kletteranlage','Rutsche','Wippe','Balanciersteg','Kletterfiguren']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze sind vorhanden']",
+    "address":"Koburger Straße / im Wildpark",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Connewitz,Süd",
+    "title":"Spielplatz Wildpark – Waldsportplatz",
+    "local_traffic":"['Straßenbahn: 9 (Haltestelle Wildpark)','Bus: 107 (Haltestelle Wildpark)']",
+    "gaming_devices":"['Seilbahn','Kletterhaus','Rutsche','Wippe','Balancierrolle','Streetballkorb']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Koburger Straße / im Wildpark",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Mitte,West",
+    "title":"Spielplatz Karlsruher Straße - Alte Salzstraße – Kletterplatz",
+    "local_traffic":"['Bus: 61, 66, 80E, 161 (Haltestelle Alte Salzstraße)']",
+    "gaming_devices":"['Kletterhaus','Doppelschaukel','Doppelrutsche']",
+    "equipment":"['Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Karlsruher Straße / Alte Salzstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Mitte,West",
+    "title":"Spielplatz Karlsruher Straße - Alte Salzstraße – 'Kleiner Kletterplatz",
+    "local_traffic":"['Bus: 61, 80E, 161 (Haltestelle Karlsruher Straße)']",
+    "gaming_devices":"['Karussell','Schaukelnest','Rutschhaus','Flüsterkugel']",
+    "equipment":"['Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Karlsruher Straße / Alte Salzstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4837463,51.3401628 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Topasstraße/Höhe Gaswerksweg",
+    "local_traffic":"['Bus: 172 (Haltestelle Opalstraße)']",
+    "gaming_devices":"['Tischtennisplatte','Klettergerüst']",
+    "equipment":"['Sandspielfläche','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Topasstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4001048,51.3418614 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neustadt-Neuschönefeld,Ost",
+    "title":"Spielplatz Weidmannstraße",
+    "local_traffic":"['Straßenbahn: 4, 7 (Haltestelle Gerichtsweg)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Weidmannstraße/Reclamstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4098156,51.3434288 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Volkmarsdorf,Ost",
+    "title":"Spielplatz Volkmarsdorfer Markt",
+    "local_traffic":"['Straßenbahn: 3, 7, 8 (Haltestelle Torgauer Platz)','Bus: 70 (Haltestelle Dornbergerstraße)']",
+    "gaming_devices":"['Wippe','Klettersteine']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Zolikoferstraße / Lukasstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.437792,51.3490982 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Sellerhausen-Stünz,Ost",
+    "title":"Spielplatz Weidlichstraße",
+    "local_traffic":"['Bus: 90 (Haltestelle Elisabeth-Schumacher-Straße)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Spielwiese mit Rodelhügel','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Weidlichstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4623766,51.3546466 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Paunsdorf,Ost",
+    "title":"Spielplatz WG Paunsdorf",
+    "local_traffic":"['Straßenbahn: 7, 8 (Haltestelle Ahornstraße)']",
+    "gaming_devices":"['Kletter-und  Rutschturm','Hängematte']",
+    "equipment":"['Schattenplätze','Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Platanenstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.427751,51.354736 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönefeld-Ost,Nordost",
+    "title":"Spielplatz WG Schönefeld",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Schwantestraße)']",
+    "gaming_devices":"['Rutschpodest','Schaukel','Federwippe','Pendel']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Bästleinstraße / Schwantesstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.303585,51.356462 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Böhlitz-Ehrenberg,Alt-West",
+    "title":"Spielplatz Zusestraße",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Barneckerstraße)']",
+    "gaming_devices":"['Doppelschaukel','Rutsche','Kletternetz']",
+    "equipment":"['Schattenplätze','Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Zusestraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4390044,51.3578412 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönefeld-Ost,Nordost",
+    "title":"Spielplatz Volksgarten",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Volksgartenstraße)']",
+    "gaming_devices":"['Raumkletternetz','Gurtsteg','Balanciersteg']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Volksgartenstraße / Torgauer Straße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.2906763,51.3619139 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Böhlitz-Ehrenberg,Alt-West",
+    "title":"Spielplatz Zur Sägemühle",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Südstraße)','Bus: 62 (Haltestelle Südstraße)']",
+    "gaming_devices":"['Kletternetz','Wippe']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Zur Sägemühle",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.382311,51.367908 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Eutritzsch,Nord",
+    "title":"Spielplatz Kletterplatz im Arthur-Bretschneider-Park",
+    "local_traffic":"['Straßenbahn: 12 (Haltestelle Gottschallstraße)','Straßenbahn: 16 (Haltestelle Eutritzscher Markt)','Bus: 85 (Haltestelle Gottschallstraße)']",
+    "gaming_devices":"['Raumkletternetz']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Kleiststraße / Gottschallstraße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4254271,51.3694767 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Thekla,Nordost",
+    "title":"Spielplatz WG Thekla",
+    "local_traffic":"['Bus: 70, 80, 83 (Neutzscher Straße)']",
+    "gaming_devices":"['Fussballtore']",
+    "equipment":"['Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Theklaer Straße",
+    "Wird geprüft durch":"René",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.342721,51.370874 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Möckern,Nordwest",
+    "title":"Spielplatz WG Möckern",
+    "local_traffic":"['Straßenbahn: 10, 11 (Haltestelle Dantestraße)','Bus: 90 (Haltestelle Slevogtstraße)']",
+    "gaming_devices":"['Kletternetz','Doppelrutsche','Drehscheibe']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Yorckstraße / Christian-Ferkel-Straße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3647038,51.3780084 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Gohlis-Nord,Nord",
+    "title":"Spielplatz Sylter Straße",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Beyerleinstraße)']",
+    "gaming_devices":"['Doppelschaukel','Kletterbalken']",
+    "equipment":"['Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Sylter Straße / Bremer Straße ",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.331449,51.380694 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wahren,Nordwest",
+    "title":"Spielplatz Zeisigplatz",
+    "local_traffic":"['Bus: 87, 88 (Haltestelle Zeisigweg)']",
+    "gaming_devices":"['Hangrutsche','Klettersteine']",
+    "equipment":"['Schattenplätze','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Zeisigweg",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.484402,51.3812849 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Sellerhausen-Stünz,Ost",
+    "title":"Spielplatz WG Sellerhausen",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Permoserstraße/Torgauer Straße)','Bus: 77, 90 (Haltestelle Permoserstraße/Torgauer Straße)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Louis-Fürnberg-Straße / Portitzer Straße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.414776,51.378281 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Mockau-Nord,Nordost",
+    "title":"Spielplatz WG Mockau",
+    "local_traffic":"['Straßenbahn: 1, 9 (Haltestelle Mockauer Post)','Bus: 70, 80 (Haltestelle Mockauer Post)']",
+    "gaming_devices":"['Kletterstein','Baumstämme']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Mockauer Straße / Tauchaer Straße",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3797123,51.398243 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wiederitzsch,Nord",
+    "title":"Spielplatz Theobald-Beer-Straße",
+    "local_traffic":"['Straßenbahn: 16 (Haltestelle Georg-Herwegh-Straße)']",
+    "gaming_devices":"['Doppelschaukel','Klettergerüst','Wipptier','Wippe']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche P+R Parkplätze an der Georg-Herwegh-Straße vorhanden']",
+    "address":"Theobald-Beer-Straße ",
+    "Wird geprüft durch":"René",
+    "Geprüft":"?"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.418122,51.410154 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Seehausen,Nord",
+    "title":"Spielplatz Wohnpark Seehausen",
+    "local_traffic":"['Bus: 86 (Haltestelle Gut Seehausen)']",
+    "gaming_devices":"['Tischtennisplatte','Doppelschaukel','Rutsche']",
+    "equipment":"['Spielwiese','Sitzgruppe','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Storchenweg",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.272952,51.252342 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Südwest,Hartmannsdorf-Knautnaundorf",
+    "title":"Spielplatz Knautnaundorfer Anger",
+    "local_traffic":"['Bus 120 (Haltestelle Werkstraße)']",
+    "gaming_devices":"['Balancierstrecke','Wippe','Tischtennisplatte','Hängematte','Holztier']",
+    "equipment":"['Schattenplätze','Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze sind vorhanden']",
+    "address":"Knautnaundorfer Anger",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.307356,51.261975 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Südwest,Hartmannsdorf-Knautnaundorf",
+    "title":"Spielplatz Erikenstraße",
+    "local_traffic":"['Bus Linie 63 (Haltestelle Erikenstraße)']",
+    "gaming_devices":"['Wippe','Federelement','Klettergerüst','Hängematte','Stehkarussell']",
+    "equipment":"['Schattenplätze','Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze sind vorhanden']",
+    "address":"Erikenstraße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.294452,51.266784 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Knautkleeberg-Knauthain,Südwest",
+    "title":"Spielplatz Am Moosbeerweg",
+    "local_traffic":"['Bus: 63 (Haltestelle Am Klucksgraben)']",
+    "gaming_devices":"['Doppelschaukel','Rutsche','Wippe']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Moosbeerweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.296818,51.267968 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Knautkleeberg-Knauthain,Südwest",
+    "title":"Spielplatz Am Schwarzdornweg",
+    "local_traffic":"['Bus: 63 (Haltestelle Am Klucksgraben)']",
+    "gaming_devices":"['Rutsche','Kletterseil']",
+    "equipment":"['Sandspielfläche','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Schwarzdornweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.292081,51.268654 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Knautkleeberg-Knauthain,Südwest",
+    "title":"Spielplatz Am Felsenthal",
+    "local_traffic":"['Bus: 63 (Haltestelle Am Klucksgraben)']",
+    "gaming_devices":"['Klettersteine']",
+    "equipment":"['Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Hagebuttenweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.294661,51.267809 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Knautkleeberg-Knauthain,Südwest",
+    "title":"Spielplatz Am Klucksgraben",
+    "local_traffic":"['Bus: 63 (Haltestelle Am Klucksgraben)']",
+    "gaming_devices":"['Hangrutsche','Kletterseil']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Klucksgraben / Büttnerweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.359067,51.270281 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wiederitzsch,Nord",
+    "title":"Spielplatz Enzianweg",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Landsberger Straße)','Bus: 87 (Haltestelle Melissenweg)']",
+    "gaming_devices":"['Kletterholzstämme']",
+    "equipment":"['Rodelhügel','Mulde','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Enzianweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.27657,51.27266 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Hartmannsdorf-Knautnaundorf,Südwest",
+    "title":"Spielplatz Am Rehbacher Anger",
+    "local_traffic":"['Bus: 120 (Haltestelle Rehbach)']",
+    "gaming_devices":"['Klettergerüst','Rutsche','Sitzkarussell']",
+    "equipment":"['Sitzgruppe mit Tisch','Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Rehbacher Anger",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.305884,51.27577 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Knautkleeberg-Knauthain,Südwest",
+    "title":"Spielplatz Am Pilzanger",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Knautkleeberg)']",
+    "gaming_devices":"['Kletterburg','Rutsche','Doppelschaukel','Wippe','Reck','Holzhaus']",
+    "equipment":"['Sandspielfläche','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Pilzanger",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4799232,51.2761837 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Liebertwolkwitz,Südost",
+    "title":"Spielplatz Edengarten",
+    "local_traffic":"['Bus: 75, 143 (Haltestelle Eulengraben)']",
+    "gaming_devices":"['Kletterpodest mit Kletterwand','Kletterpodest mit Rutschstange']",
+    "equipment":"['Spielwiese','Bank','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Schäferweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4715259,51.2770805 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Liebertwolkwitz,Südost",
+    "title":"Spielplatz Emil-Kluge-Park",
+    "local_traffic":"['Bus: 75 (Haltestelle Störmthaler Straße)']",
+    "gaming_devices":"['Fußballtore','Streetballkorb']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Emil-Kluge-Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.47212,51.278608 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Liebertwolkwitz,Südost",
+    "title":"Spielplatz Siedlereck",
+    "local_traffic":"['Bus: 75 (Haltestelle Störmthaler Straße)']",
+    "gaming_devices":"['Doppelschaukel','Wippe','Kletternetz','Rutschturm','Kletterwand','Federbrett','Schaufelbagger','Holzspielbank']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Siedlereck / Oberholzstraße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.466681,51.277167 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Liebertwolkwitz,Südost",
+    "title":"Spielplatz August-Scheibe-Straße",
+    "local_traffic":"['Bus: 75, 143 (Haltestelle Störmthaler Straße)']",
+    "gaming_devices":"['Doppelschaukel','Rutschturm']",
+    "equipment":"['Sandspielfläche','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"August-Scheibe-Straße / Carl-Munde-Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.463694,51.279219 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Liebertwolkwitz,Südost",
+    "title":"Spielplatz An der Badeanlage",
+    "local_traffic":"['Bus: 75 (Haltestelle Zur Alten Sandgrube)']",
+    "gaming_devices":"['Doppelseilbahn','Skaterrampe']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Zur Kuhweide",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.459666,51.281271 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Liebertwolkwitz,Südost",
+    "title":"Spielplatz Dorotheenring",
+    "local_traffic":"['Bus: 75 (Haltestelle Zur Alten Sandgrube)']",
+    "gaming_devices":"['Schaukel','Kletternetz','Hängenetz','Wippe']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Dorotheenring / Auguste-Schulze-Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.461315,51.284697 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Liebertwolkwitz,Südost",
+    "title":"Spielplatz Am Angerteich",
+    "local_traffic":"['Bus: 75, 172 (Haltestelle Schwarzes Ross)']",
+    "gaming_devices":"['Reck','Klettergerüst','Seilschaukel']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Jahnstraße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.351281,51.282934 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Großzschocher,Südwest",
+    "title":"Spielplatz Am Cospudener See",
+    "local_traffic":"['Bus: 65 (Haltestelle Nordstrand)']",
+    "gaming_devices":"['Kletterhölzer','Seile']",
+    "equipment":"['Spielwiese','Bänke','Hinweis:','Der Zugang zum Spielplatz ist nur über eine Treppe oder die Böschung möglich.','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Lauerscher Weg",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.381792,51.286732 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Dölitz-Dösen,Süd",
+    "title":"Spielplatz Das KinderReich- Agra",
+    "local_traffic":"['Straßenbahn: 11 (Haltestelle Leinestraße)']",
+    "gaming_devices":"['Kletterhölzer','Holzhaus','Wasserpumpe']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Im Dölitzer Holz",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.463816,51.28617 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Liebertwolkwitz,Südost",
+    "title":"Spielplatz Am Gänseanger",
+    "local_traffic":"['Bus: 172 (Haltestelle Roßstraße)']",
+    "gaming_devices":"['Doppelschaukel','Reck','Klettergerüst']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Gänseanger / Alte Tauchaer Straße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4358545,51.2901967 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Meusdorf,Südost",
+    "title":"Spielplatz Siedlung Meusdorf",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Meusdorf)','Bus: 75, 172 (Haltestelle Monarchenhügel)']",
+    "gaming_devices":"['Seilbahn','Klettergerüst','Hängematte','Rutsche','Wippe','Wipptier','Tischtennisplatten','Balancierbalken']",
+    "equipment":"['Schattenplätze','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Schwarzenbergweg",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.421431,51.290698 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Meusdorf,Südost",
+    "title":"Spielplatz Park Dösen",
+    "local_traffic":"['Bus: 75, 172 (Haltestelle Pahlenweg)']",
+    "gaming_devices":"['Fussballtore']",
+    "equipment":"['Schattenplätze','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"im Park / Höhe Paul-Flechsig-Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.389546,51.29371 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Dölitz-Dösen,Süd",
+    "title":"Spielplatz Gersterstraße",
+    "local_traffic":"['Straßenbahn: 11 (Friederikenstraße)']",
+    "gaming_devices":"['Rutsch- und Kletterkombination Sonne, Mond und Sterne','Doppelschaukel','Tischtennisplatte']",
+    "equipment":"['Sandspielflächen','Spielwiese','Bänke','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Gersterstraße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.325369,51.313603 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Kleinzschocher,Südwest",
+    "title":"Spielplatz Martinsplatz",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Kötzschauer Straße)']",
+    "gaming_devices":"['Kletterholzgerüst','Findlinge','Balancierstrecke']",
+    "equipment":"['Rodelhügel','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Dieskaustraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.383019,51.304396 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Connewitz,Süd",
+    "title":"Spielplatz Hildebrandplatz",
+    "local_traffic":"['Straßenbahn: 11 (Haltestelle Hildbrandstraße)']",
+    "gaming_devices":"['Tischtennisplatten','Drehscheibe','Doppelschaukel','Rutschturm','Balltrichter','Kletterbogen','Karussell','Schaukel','Holzsalamander','Weitspungplatz','Bolzplatz']",
+    "equipment":"['Spielwiese','Findlinge','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Hildbrandstraße / Bornaische Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.386276,51.29841 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lößnig,Süd",
+    "title":"Spielplatz Rembrandtplatz",
+    "local_traffic":"['Straßenbahn: 11 (Haltestelle S-Bahnhof Connewitz)']",
+    "gaming_devices":"['Doppelschaukel','Kletter- und Rutschturm','Tischtennisplatte']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Rembrandtstraße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.443922,51.296427 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Holzhausen,Südost",
+    "title":"Spielplatz Eisenschmidtplatz",
+    "local_traffic":"['Straßenbahn: 2, 15 (Haltestelle Meusdorf)','Bus: 75, 172 (Haltestelle Meusdorf)']",
+    "gaming_devices":"['Kletter- und Rutschturm','Trampolin','Wippe','Schaukel']",
+    "equipment":"['Spielwiese','Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Parkstraße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.440571,51.300898 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Probstheida,Südost",
+    "title":"Spielplatz Am Polenweg",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Franzosenallee)','Bus: 76 (Haltestelle Schweizerbogen)']",
+    "gaming_devices":"['Sandspielkombination','Karussell']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Polenweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.438068,51.301036 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Probstheida,Südost",
+    "title":"Spielplatz Am Tschechenbogen",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Franzosenallee)','Bus: 76 (Haltestelle Schweizerbogen)']",
+    "gaming_devices":"['Klettergerüst','Rutschturm','Schaukel']",
+    "equipment":"['Schattenplätze','Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Tschechenbogen",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3299312,51.300274 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Großzschocher,Südwest",
+    "title":"Spielplatz Gutspark Großzschocher",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Kunzestraße)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Buttergasse",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.435003,51.301612 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Probstheida,Südost",
+    "title":"Spielplatz Sonnenpark",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Franzosenallee)','Bus: 76 (Haltestelle Franzosenallee)']",
+    "gaming_devices":"['Reifenpendel','Wipptiere','Kletternetz']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Buckyweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.514585,51.304819 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Althen-Kleinpösna,Ost",
+    "title":"Spielplatz Am Pösgraben",
+    "local_traffic":"['Bus: 73 (Haltestelle Kleinpösna)']",
+    "gaming_devices":"['Doppelschaukel','Kletter- und Rutschturm','Holztische und Stühle']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Pösgraben",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.324602,51.305514 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Großzschocher,Südwest",
+    "title":"Spielplatz Bismarckstraße",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Kunzestraße)']",
+    "gaming_devices":"['Rutschenhügel','Trampolin','Wippe','Wackeltier','Matschtische','Holzkugelbahn','Torstäbe']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Bismarckstraße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.513801,51.306958 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Althen-Kleinpösna,Ost",
+    "title":"Spielplatz Am Dorfteich",
+    "local_traffic":"['Bus: 73 (Haltestelle Kleinpösna)']",
+    "gaming_devices":"['Kletterwand','Karussell','Wipptier']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Dorfteich / Durch die Felder",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4637168,51.3051188 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Südost,Holzhausen",
+    "title":"Spielplatz Azaleenweg",
+    "local_traffic":"['Bus Linie 74, 172 (Haltestelle Sächisches Haus)']",
+    "gaming_devices":"['Holzeidechse']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze sind vorhanden']",
+    "address":"Azaleenweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.455696,51.305447 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Holzhausen,Südost",
+    "title":"Spielplatz Arthur-Polenz-Straße",
+    "local_traffic":"['Bus: 74 (Arthur-Polenz-Straße)']",
+    "gaming_devices":"['Wipptier','Reifenpendel','Kletterpodest','Pendelwippe','Federsitz']",
+    "equipment":"['Schattenplätze','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Arthur-Polenz-Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.390896,51.306028 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Marienbrunn,Süd",
+    "title":"Spielplatz An der Märchenwiese ",
+    "local_traffic":"['Straßenbahn: 10, 16 (Haltestelle An der Märchenwiese)']",
+    "gaming_devices":"['Tischtennisplatte','Hangrutsche','Hängebrücke']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"An der Märchenwiese",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.374028,51.307455 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Connewitz,Süd",
+    "title":"Spielplatz Herderplatz",
+    "local_traffic":"['Straßenbahn: 9 (Haltestelle Mathildenstraße)','Bus: 107 (Haltestelle Mathildenstraße)']",
+    "gaming_devices":"['Kletternetz','Rutschstangen','Kletterpyramide','Tischtennisplatten','Rollenrutsche','Pyramidenrutsche','Minirutschen']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Herderstraße / Wolfgang-Heinze-Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.321471,51.307293 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Großzschocher,Südwest",
+    "title":"Spielplatz Arthur-Nagel-Straße",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Arthur-Nagel-Straße)']",
+    "gaming_devices":"['Tischtennisplatte','Flüsterkugel','Streetballkorb']",
+    "equipment":"['Schattenplätze','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Arthur-Nagel-Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.393407,51.308241 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Marienbrunn,Süd",
+    "title":"Spielplatz Hirtenweg",
+    "local_traffic":"['Straßenbahn: 10, 16 (Haltestelle Triftweg)']",
+    "gaming_devices":"['Streetballplatz','2 Tischtennisplatten','Klettergerüst','Brettspieltische']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Hirtenweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.373467,51.308252 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Gohlis-Süd,Nord",
+    "title":"Spielplatz Auerbachplatz",
+    "local_traffic":"['Straßenbahn: 10, 11, 12 (Haltestelle Georg-Schuhmann-Straße/Lützowstraße)','S-Bahn: S10 (Haltestelle Gohlis)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Auerbachplatz",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.271123,51.312 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lausen-Grünau,West",
+    "title":"Spielplatz Deiwitzweg – Sandplatz",
+    "local_traffic":"['Straßenbahn: 1 (Haltestelle Krakauer Straße)','Bus: 61, 66, 80E, 161 (Haltestelle Krakauer Straße)']",
+    "gaming_devices":"",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Alte Salzstraße / Deiwitzweg",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.451921,51.420893 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Seehausen,Nord",
+    "title":"Spielplatz Dorfanger Hohenheida",
+    "local_traffic":"['Bus: 86, 176 (Haltestelle Am Anger)']",
+    "gaming_devices":"['Streetballkorb','Torwand','Kletterturm','Rutschturm','Doppelschaukel','Wipptier','Mastpendel','Tischtennisplatte','Holztiere']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Grillplatz','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Anger / An der Hauptstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.269671,51.311944 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"West,Grünau-Siedlung",
+    "title":"Spielplatz Krakauer Straße",
+    "local_traffic":"['Straßenbahn: 1 (Haltestelle Krakauer Straße)','Bus: 61, 66, 80E, 161 (Haltestelle Krakauer Straße)']",
+    "gaming_devices":"['Fußballfeld','Streetballplatz','Volleyball']",
+    "equipment":"['Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Krakauer Straße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.266458,51.314714 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lausen-Grünau,West",
+    "title":"Spielplatz Brackestraße",
+    "local_traffic":"['Bus: 62, 66 (Haltestelle Selliner Straße - Gesundheitszentrum)']",
+    "gaming_devices":"['Kletternetz']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Brackestraße ",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.261387,51.314284 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lausen-Grünau,West",
+    "title":"Spielplatz Selliner Straße",
+    "local_traffic":"['Bus: 62, 66 (Haltestelle Selliner Straße - Gesundheitszentrum)']",
+    "gaming_devices":"['Kletterpodest','Rutsche','Schaukel']",
+    "equipment":"['Sitzgruppe','Sandspielfläche','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Selliner Straße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.28818,51.316049 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Mitte,West",
+    "title":"Spielplatz An der Fröbel-Schule",
+    "local_traffic":"['Bus: 61, 66, 80E, 161 (Haltestelle Alte Salzstraße)']",
+    "gaming_devices":"['Tischtennisplatten','Pendel','Wipptiere']",
+    "equipment":"['Streetballfeld','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Alte Salzstraße / Mannheimer Straße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.419902,51.314547 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Gregoryplatz",
+    "local_traffic":"['Straßenbahn: 2, 15 (Haltestelle Völkerschlachtdenkmal)']",
+    "gaming_devices":"['Summstein','Findlinge']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Naunhofer Straße / Gletschersteinstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.417721,51.315725 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Gustav-Schwabe-Platz",
+    "local_traffic":"['Straßenbahn: 2, 15 (Haltestelle Völkerschlachtdenkmal)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Findlinge','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Ludolf-Colditz-Straße / Naunhofer Straße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.32416,51.315744 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Kleinzschocher,Südwest",
+    "title":"Spielplatz Schwartzeplatz",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Schwartzestraße)']",
+    "gaming_devices":"['Raumkletternetz','Holzhaus','Wipptiere','Karussell']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Schwartzestraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.365169,51.3167 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Südvorstadt,Süd",
+    "title":"Spielplatz Am Fockeberg",
+    "local_traffic":"['Straßenbahn: 9, 10, 11 (HTWK)','Bus: 70, 89 (HTWK)']",
+    "gaming_devices":"['Kletterpferd','Balancierstrecke','Reifenschaukel','Karussell','Reck','Wippe','Matschtisch','Steintier','Wipptiere','Rutsche','Kletterzelt','Tischtennisplatte']",
+    "equipment":"['Ballspielplatz','Spielwiese','Schattenplätze','Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Fockestraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.329734,51.317157 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Kleinzschocher,Südwest",
+    "title":"Spielplatz Am Obstgarten",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Schwartzestraße)']",
+    "gaming_devices":"['Wipptier','Podest','Holzfigur']",
+    "equipment":"['Spielwiese','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Durchgang Windorfer Straße / Kantatenweg",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.262821,51.318082 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Nord,West",
+    "title":"Spielplatz Am kleinen Feld",
+    "local_traffic":"['Bus: 62, 65, 66 (Haltestelle Am kleinen Feld)']",
+    "gaming_devices":"['Kletterpodest','Rutsche']",
+    "equipment":"['Schattenplätze','Bänke','Sandspielfläche','Sitzecke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am kleinen Feld",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.269776,51.318791 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Nord,West",
+    "title":"Spielplatz Andromedaweg",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Plovdiver Straße)','Bus: 62, 65, 66 (Haltestelle Plovdiver Straße)']",
+    "gaming_devices":"['Kletterpyramide']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Andromedaweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.278303,51.322625 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönau,West",
+    "title":"Spielplatz Schönauer Welle – Tischtennisplatz“;['Straßenbahn: 15 (Haltestelle Am Kirchberg)','Bus: 62 (Haltestelle Kiewer Straße)','Bus: 61, 65, 80E, 161 (Haltestelle Am Kirchberg)'];['Tischtennisplatte'];['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden'];unterhalb Römhilder Weg / Kiewer Straße;51.3192051;12.2776237\nLeipzig;Schönau,West;Spielplatz Schönauer Welle – Tischtennisplatz“",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Am Kirchberg)','Bus: 62 (Haltestelle Kiewer Straße)','Bus: 61, 65, 80E, 161 (Haltestelle Am Kirchberg)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"unterhalb Römhilder Weg / Kiewer Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.377157,51.322885 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Südvorstadt,Süd",
+    "title":"Spielplatz Am Amtsgericht",
+    "local_traffic":"['Straßenbahn: 9 (Körnerstraße)','Bus: 60 (Körnerstraße)']",
+    "gaming_devices":"['Doppelschaukel','Tischtennisplatte','Kletterhaus']",
+    "equipment":"['Schattenplätze','Spielwiese','Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Arndtstraße / Bernhard-Göring-Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.377253,51.317104 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Südvorstadt,Süd",
+    "title":"Spielplatz Steinplatz",
+    "local_traffic":"['Straßenbahn: 9 (Haltestelle Steinplatz)','Bus: 100 (Haltestelle Steinplatz)']",
+    "gaming_devices":"['Kletteranlage','Kletterseile','Hängekorb','Matschtisch','Holzsteg','Schaukel','Kletternetz','Rutschen','Gurtsteg','Klettersteg']",
+    "equipment":"['Spielwiese','Bänke','Sandspielfläche','Findlinge','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Steinstraße / Bernhard-Göring-Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.374682,51.319225 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Südvorstadt,Süd",
+    "title":"Spielplatz Alexis-Schuhmann-Platz",
+    "local_traffic":"['Straßenbahn: 10, 11 (Karl-Liebknecht-Straße/Kurt-Eisner-Straße)','Bus: 60, 74 (Karl-Liebknecht-Straße/Kurt-Eisner-Straße)']",
+    "gaming_devices":"['Kletter- und Rutschturm','Balancierseil','Stehwippe','Tischtennisplatte','Schaukel']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Andreasstraße / Scharnhorststraße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.264303,51.319488 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Nord,West",
+    "title":"Spielplatz Neue Leipziger Straße",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Plovdiver Straße)','Bus: 62, 65, 66 (Haltestelle Plovdiver Straße)']",
+    "gaming_devices":"['Kletterturm','Rutsche','Wipptier','Doppelschaukel']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Neue Leipziger Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.337913,51.319783 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schleußig,Südwest",
+    "title":"Spielplatz Oeserstraße",
+    "local_traffic":"['Straßenbahn: 1, 2 (Haltestelle Rödelstraße)','Bus: 60, 74 (Haltestelle Rödelstraße)']",
+    "gaming_devices":"['Gurtsteg','Rutschturm','Drehscheibe','Tischtennisplatte','Balancierseil','Streetballkorb']",
+    "equipment":"['Spielwiese','Sandspielfläche','Bänke','Rodelhügel','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Oeserstraße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.284794,51.320108 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Mitte,West",
+    "title":"Spielplatz An den Gleisen';['Straßenbahn: 8, 15 (Haltestelle Schönauer Ring)','Bus: 61, 65, 66, 80E, 161 (Haltestelle Schönauer Ring)'];['Kletterburg','Rutsche','Holzsteg','Kletterseil'];['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden'];Höhe Ulmer Straße;51.3198799;12.2856425\nLeipzig;Grünau-Mitte,West;Spielplatz An den Gleisen'",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Schönauer Ring)','Bus: 61, 65, 66, 80E, 161 (Haltestelle Schönauer Ring)']",
+    "gaming_devices":"['Kletterburg','Rutsche','Holzsteg','Kletterseil']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Höhe Ulmer Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.377735,51.323662 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Südvorstadt,Süd",
+    "title":"Spielplatz Albrecht-Dürer-Platz",
+    "local_traffic":"['Straßenbahn: 9 (Körnerstraße)','Bus: 60 (Körnerstraße)']",
+    "gaming_devices":"['Kletternetz']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Arthur-Hoffmann-Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.326357,51.320721 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Plagwitz,Südwest",
+    "title":"Spielplatz Gießerplatz",
+    "local_traffic":"['Straßenbahn: 1, 2 (Haltestelle Antonienstraße)','Bus: 60 (Haltestelle Antonienstraße)']",
+    "gaming_devices":"['Kletter- und Rutschgerüst','Nestschaukel','Kletternetz','Reck']",
+    "equipment":"['Sandspielfläche','Bänke','Spielwiese','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Gießerstraße / Antonienstraße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.381313,51.323985 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Südvorstadt,Süd",
+    "title":"Spielplatz Schenkendorfplatz",
+    "local_traffic":"['Straßenbahn: 9 (Haltestelle Körnerstraße)','Bus: 60 (Haltestelle Körnerstraße)']",
+    "gaming_devices":"['Gurtsteg','Kletternetz','Hängeseile']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Schenkendorfstraße / Lößniger Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.372676,51.319101 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Südvorstadt,Süd",
+    "title":"Spielplatz Heinrich-Schütz-Platz",
+    "local_traffic":"['Straßenbahn: 10, 11 (Haltestelle Karl-Liebknecht-Straße/Kurt-Eisner-Straße)','Bus: 60, 74 (Haltestelle Karl-Liebknecht-Straße/Kurt-Eisner-Straße)']",
+    "gaming_devices":"['Stangensegel','Drehpilze','Kletterstangen','Tischtennisplatten','Streetballfeld']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Hardenbergstraße/Karl-Liebknecht-Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.47747,51.323139 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Baalsdorf,Ost",
+    "title":"Spielplatz Balduinplatz",
+    "local_traffic":"['Bus: 73, 172 (Haltestelle Baalsdorfer Straße)']",
+    "gaming_devices":"['Mastkreuzpendel','Drehscheibe','Tischtennisplatte','Rutschturm','Kletterwand','Wippe','Wipptier']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Kurt-Hänselmann-Weg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.28824,51.32096 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Mitte,West",
+    "title":"Spielplatz Offenburger Straße",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Schönauer Ring)','Bus: 61, 65, 66, 80E, 161 (Haltestelle Schönauer Ring)']",
+    "gaming_devices":"['Tischtennisplatte','Drehscheibe']",
+    "equipment":"['Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Offenburger Straße",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.286764,51.319616 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Mitte,West",
+    "title":"Spielplatz Heidelberger Straße",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Schönauer Ring)','Bus: 61, 65, 66, 80E, 161 (Haltestelle Schönauer Ring)']",
+    "gaming_devices":"['Tischtennisplatten']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Heidelberger Straße ",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.433412,51.321259 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Ampéreweg",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Holzhäuser Straße)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Spielwiese','Rundbank','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Ampéreweg / Jouleweg",
+    "Wird geprüft durch":"Max",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.422832,51.322194 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Stötteritzer Wäldchen – Kleiner Schneck",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Kolmstraße)','Bus: 74, 79 (Haltestelle Kolmstraße)']",
+    "gaming_devices":"['Kletterholz','Holztier Kleiner Schneck','Spirale']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Oberdorfstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4248776,51.3214427 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Stötteritzer Wäldchen – Kletterplatz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Kolmstraße)','Bus: 74, 79 (Haltestelle Kolmstraße)']",
+    "gaming_devices":"['Kletterholz Waldtelefon']",
+    "equipment":"['Spielwiese','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Oberdorfstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4248776,51.3214427 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Stötteritzer Wäldchen – Rodelhügel",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Kolmstraße)','Bus: 74, 79 (Haltestelle Kolmstraße)']",
+    "gaming_devices":"",
+    "equipment":"['Rodelhügel','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Oberdorfstraße",
+    "Wird geprüft durch":"Hans",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4248776,51.3214427 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Stötteritzer Wäldchen – Tischtennisplatz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Kolmstraße)','Bus: 74, 79 (Haltestelle Kolmstraße)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Oberdorfstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.422939,51.322825 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Stötteritzer Wäldchen – Waldspielplatz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Kolmstraße)','Bus: 74, 79 (Haltestelle Kolmstraße)']",
+    "gaming_devices":"['Holzklettergerüst']",
+    "equipment":"['Sandspielfläche','Findlinge','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Oberdorfstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.422955,51.322789 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Marienkirchplatz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Kolmstraße)','Bus: 74, 79 (Haltestelle Kolmstraße)']",
+    "gaming_devices":"['Klettersteine']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Sommerfelder Straße / Lochmannstraße ",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.298094,51.320369 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Ost,West",
+    "title":"Spielplatz Am Übergang",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Grünauer Allee)']",
+    "gaming_devices":"['Tischtennisplatten','Streetballkorb','Fußballtore']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Übergang",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed (unsicher)"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.298094,51.320369 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Ost,West",
+    "title":"Spielplatz Skaterpark",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Parkallee)','Bus: 61, 161 (Haltestelle Weißdornstraße)']",
+    "gaming_devices":"['Skaterparcour']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Übergang",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4843066,51.3227301 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Baalsdorf,Ost",
+    "title":"Spielplatz Baalsdorfer Anger",
+    "local_traffic":"['Bus: 73, 172 (Haltestelle Baalsdorfer Straße)']",
+    "gaming_devices":"['Wipptier','Wippe','Klettergerüst']",
+    "equipment":"['Schattenplätze','Sandspielfläche','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Baalsdorfer Anger",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.278259,51.322614 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönau,West",
+    "title":"Spielplatz Schönauer Welle – Sandspielplatz“;['Straßenbahn: 8 (Haltestelle Grünau-Nord)','Bus: 62 (Haltestelle Kiewer Straße)'];['Klettersteine'];['Bänke','Sandspielfläche','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden'];unterhalb Römhilder Weg;51.3227469;12.2774825\nLeipzig;Schönau,West;Spielplatz Schönauer Welle – Sandspielplatz“",
+    "local_traffic":"['Straßenbahn: 8 (Haltestelle Grünau-Nord)','Bus: 62 (Haltestelle Kiewer Straße)']",
+    "gaming_devices":"['Klettersteine']",
+    "equipment":"['Bänke','Sandspielfläche','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"unterhalb Römhilder Weg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.2774825,51.3227469 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönau,West",
+    "title":"Spielplatz Schönauer Welle – Schaukelplatz“;['Straßenbahn: 8 (Grünau-Nord)','Bus: 62 (Kiewer Straße)'];['Sechseckschaukel'];['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden'];unterhalb Römhilder Weg;51.3227469;12.2774825\nLeipzig;Schönau,West;Spielplatz Schönauer Welle – Schaukelplatz“",
+    "local_traffic":"['Straßenbahn: 8 (Grünau-Nord)','Bus: 62 (Kiewer Straße)']",
+    "gaming_devices":"['Sechseckschaukel']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"unterhalb Römhilder Weg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3268262,51.323773 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lindenau,Alt-West",
+    "title":"Spielplatz Brückenplatz",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Henriettenstraße)']",
+    "gaming_devices":"['2 Wasserkurbeln','Wasserbahn','Wasserpumpe',' ']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Gießerbrücke / Gießerstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3472887,51.3237829 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schleußig,Südwest",
+    "title":"Spielplatz Die Nonne",
+    "local_traffic":"['Straßenbahn: 1, 2 (Haltestelle Stieglitzstraße)','Bus: 74 (Haltestelle Stieglitzstraße)']",
+    "gaming_devices":"['Kletter- und Rutschturm','Tischtennisplatte','Wippe','Karussell','Holzstemmgerät','Hängematte','Naturelemente','Minireck']",
+    "equipment":"['Schattenplätze','Sandspielfläche','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Nonnenweg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.282604,51.323902 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönau,West",
+    "title":"Spielplatz Schönauer Welle – Kletterplatz“;['Straßenbahn: 8 (Haltestelle Grünau-Nord)','Bus: 62 (Haltestelle Kiewer Straße)'];['Kletterstäbe'];['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden'];Dornburger Weg;51.324379;12.2822712\nLeipzig;Schönau,West;Spielplatz Schönauer Welle – Kletterplatz“",
+    "local_traffic":"['Straßenbahn: 8 (Haltestelle Grünau-Nord)','Bus: 62 (Haltestelle Kiewer Straße)']",
+    "gaming_devices":"['Kletterstäbe']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Dornburger Weg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.282562,51.325453 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönau,West",
+    "title":"Spielplatz Schönauer Welle – Sportwiese",
+    "local_traffic":"['Straßenbahn: 8 (Haltestelle Grünau-Nord)','Bus: 62 (Haltestelle Kiewer Straße)']",
+    "gaming_devices":"",
+    "equipment":"['Sportwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Dornburger Weg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.2954956,51.3247841 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Ost,West",
+    "title":"Spielplatz An der Parkallee – Holzplatz",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Parkallee)']",
+    "gaming_devices":"['Holz- und Klettertier Nashorn']",
+    "equipment":"['Bänke','Sandspielfläche','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Parkallee ",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.290898,51.327766 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Ost,West",
+    "title":"Spielplatz An der Parkallee – Tischtennisplatz",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Parkallee)','Bus: 61, 161 (Haltestelle Weißdornstraße)']",
+    "gaming_devices":"['Tischtennisplatten']",
+    "equipment":"['Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Parkallee",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.396595,51.328625 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Südost,Mitte",
+    "title":"Spielplatz Fußballfeld im Friedenspark",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Straßenbahn: 2, 16 (Haltestelle Deutsche Nationalbibliothek)','Bus: 60 (Haltestelle Ostplatz)','Bus: 74 (Haltestelle Deutsche Nationalbibliothek)']",
+    "gaming_devices":"['Fußballtore','Torwand']",
+    "equipment":"['Spielwiese','Bänke','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Linnéstraße / Phillip-Rosenthal-Straße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.397089,51.325474 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Südost,Mitte",
+    "title":"Spielplatz Kletterplatz im Friedenspark",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Straßenbahn: 2, 16 (Haltestelle Deutsche Nationalbibliothek)','Bus: 60 (Haltestelle Ostplatz)','Bus: 74 (Haltestelle Deutsche Nationalbibliothek)']",
+    "gaming_devices":"['Kletterturm','Rutschturm','Kletterpodest','Wipptiere','Schaukel','Wippe']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Linnéstraße / Phillip-Rosenthal-Straße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.392638,51.3251476 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Südost,Mitte",
+    "title":"Spielplatz Rodelhügel im Friedenspark",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Straßenbahn: 2, 16 (Haltestelle Deutsche Nationalbibliothek)','Bus: 60 (Haltestelle Ostplatz)','Bus: 74 (Haltestelle Deutsche Nationalbibliothek)']",
+    "gaming_devices":"",
+    "equipment":"['Rodelhügel','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Linnéstraße / Phillip-Rosenthal-Straße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.396271,51.32541 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Südost,Mitte",
+    "title":"Spielplatz Streetballplatz im Friedenspark",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Straßenbahn: 2, 16 (Haltestelle Deutsche Nationalbibliothek)','Bus: 60 (Haltestelle Ostplatz)','Bus: 74 (Haltestelle Deutsche Nationalbibliothek)']",
+    "gaming_devices":"['Streetballkorb']",
+    "equipment":"['Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Linnéstraße / Phillip-Rosenthal-Straße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.269871,51.324623 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Nord,West",
+    "title":"Spielplatz Am Kindergarten",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Saturnstraße)']",
+    "gaming_devices":"['Kletterturm','Rutsche','Schaukel','Steindino']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Neptunweg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.2685109,51.3254062 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Nord,West",
+    "title":"Spielplatz Spielhügel Am Neptunweg",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Saturnstraße)']",
+    "gaming_devices":"['Tischtennisplatten','Kletterhaus','Hängematten','Schaukel','Kletterburg','Doppelschaukel']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Neptunweg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.37537,51.325507 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Süd,Mitte",
+    "title":"Spielplatz Körnerplatz",
+    "local_traffic":"['Straßenbahn: 10, 11 (Haltestelle Südplatz)']",
+    "gaming_devices":"['Kletterpyramide','Kletterturm']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Körnerplatz",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.302236,51.3259121 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Ost,West",
+    "title":"Spielplatz Grünauer Allee",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Grünauer Allee)']",
+    "gaming_devices":"['Wasserpumpe','Holzhaus','Federplatten','Doppelschaukel','Kletterturm','Drehbagger']",
+    "equipment":"['Sandspielfläche','Bänke','Spielwiese','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Grünauer Allee ",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3192088,51.326078 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lausen-Grünau,West",
+    "title":"Spielplatz Alte Salzstraße – Am Kindergarten",
+    "local_traffic":"['Straßenbahn: 1 (Haltestelle Zschampertaue)','Bus: 61, 66, 80E, 161 (Haltestelle Zschampertaue)']",
+    "gaming_devices":"['Kletterturm','Rutsche','Kletternetz','Schaukel']",
+    "equipment":"['Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Alte Salzstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3192088,51.326078 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Mitte,West",
+    "title":"Spielplatz Alte Salzstraße – Ballplatz",
+    "local_traffic":"['Bus: 65, 66 (Haltestelle Allee Center)']",
+    "gaming_devices":"['Tischtennisplatte','Tore']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Alte Salzstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3192088,51.326078 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Mitte,West",
+    "title":"Spielplatz Alte Salzstraße – Kletterplatz",
+    "local_traffic":"['Bus: 65, 66 (Haltestelle Allee Center)']",
+    "gaming_devices":"['Kletterhaus','Rutsche']",
+    "equipment":"['Rodelhügel','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Alte Salzstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3192088,51.326078 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Grünau-Ost,West",
+    "title":"Spielplatz Alte Salzstraße",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Parkallee)']",
+    "gaming_devices":"['Tischtennisplatte','Rutsche','Rutsche mit Rollstuhlzugan','Federplatten']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Alte Salzstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3192088,51.326078 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lausen-Grünau,West",
+    "title":"Spielplatz Deiwitzweg – Kletterplatz",
+    "local_traffic":"['Straßenbahn: 1 (Krakauer Straße)','Bus: 61, 66, 80E, 161 (Schönauer Ring)']",
+    "gaming_devices":"['Kletterturm','Rutsche','Federwippe']",
+    "equipment":"['Bänke','Sandspielfläche','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Deiwitzweg /Alte Salzstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.286416,51.327717 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönau,West",
+    "title":"Spielplatz Jugendkuhle",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Schönauer Ring)','Bus: 61, 65, 66, 80E, 161 (HaltestelleSchönauer Ring)']",
+    "gaming_devices":"['Fußballtore','Tischtennisplatten','Streetballkorb']",
+    "equipment":"['Bänke','Pavillon','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Stuttgarter Allee / Dölziger Weg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.254497,51.32142 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Miltitz,West",
+    "title":"Spielplatz Park Miltitz",
+    "local_traffic":"['Bus: 65 (Haltestelle Geschwister-Scholl-Straße)']",
+    "gaming_devices":"['Tischtennisplatten','Streetballkorb']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Rathausring / Geschwister-Scholl-Straße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.409591,51.327166 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Simonsplatz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle S-Bahnhof Stötteritz)']",
+    "gaming_devices":"['Kletterturm mit Rutsche','Schaukel','Tischtennisplatte']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Nobbeweg / Reinhold-Krüger-Straße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.369993,51.328128 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Süd,Mitte",
+    "title":"Spielplatz Neue Ufer",
+    "local_traffic":"['Straßenbahn: 10, 11 (Haltestelle Hohe Straße)']",
+    "gaming_devices":"['Schiff mit Rutsch- und Kletterturm','Wasserpumpe','Kletternetz','Findlinge']",
+    "equipment":"['Wasserzugang','Sandspielfläche','Sitzsteine','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Wundstraße Kreuzung Dufourstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.33178,51.328195 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Plagwitz,Südwest",
+    "title":"Spielplatz Stadtteilpark Plagwitz",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Elster-Passage)','Bus: 74 (Haltestelle Elster-Passage)']",
+    "gaming_devices":"['Hangrutsche','Kletterwürfel','Federteller','Drehscheibe','Kletterstifte']",
+    "equipment":"['Boulplatz','Spielwiese','Sandspielfläche','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Industriestraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.286345,51.327749 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönau,West",
+    "title":"Spielplatz Don Quichotte",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Schönauer Ring)','Bus: 61, 65, 66, 80E, 161 (Haltestelle Schönauer Ring)']",
+    "gaming_devices":"['Kletterhaus','Hängematte','Windmühle','Hangrutsche','Sandspieltische','Holzfiguren']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Lindennaundorfer Weg",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.362458,51.328356 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Süd,Mitte",
+    "title":"Spielplatz Rennbahnweg",
+    "local_traffic":"['Bus: 89 (Haltestelle Telemannstraße)']",
+    "gaming_devices":"['Kletterhaus','Rutsche','Raumkletternetze','Hangrutsche','Drehscheibe','Karussell','Schaukelnest','Balanciersteg','Tischtennisplatte','Kletterröhren','Wasserspiel','Wipptiere','Minirutsche','Minikletterhaus']",
+    "equipment":"['Spielwiese','Sandspielflächen','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Rennbahnweg",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.401954,51.328154 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Oswaldplatz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Riebeckstraße/Stötteritzer Straße)','Bus: 70 (Haltestelle Riebeckstraße/Stötteritzer Straße)']",
+    "gaming_devices":"['Streetballkorb','Drehteller','Tischtennisplatte']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Oswaldstraße / Witzgallstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.410681,51.331568 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Alfred-Frank-Platz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Riebeckstraße/Oststraße)','Bus: 60 (Haltestelle Holsteinstraße)','Bus: 70 (Haltestelle Riebeckstraße/Oststraße)']",
+    "gaming_devices":"['Tischtennisplatte','Klettergerüst mit Rutsche','Schaukel','Matschtisch']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Lipsiusstraße / Holsteinstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.41063,51.331554 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Reudnitzer Terrassen",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Riebeckstraße/Oststraße)','Bus: 60 (Haltestelle Riebeckstraße/Oststraße)']",
+    "gaming_devices":"['Schaukel','Hängematte']",
+    "equipment":"['Schattenplätze','Spielwiese','Bänke','Findlinge','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Oststraße / Holsteinstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.357057,51.327559 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Süd,Mitte",
+    "title":"Spielplatz Max-Reger-Allee",
+    "local_traffic":"['Bus: 89 (Haltestelle Telemannstraße)']",
+    "gaming_devices":"[' ','Steinrutsche Elefant','Steinrutsche Schwan','Steintier Pony',' ']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Max-Reger-Allee",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.316858,51.32951 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neulindenau,Alt-West",
+    "title":"Spielplatz Bausestraße",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Radiusstraße)','Bus: 80 (Haltetelle Radiusstraße)']",
+    "gaming_devices":"['Tischtennisplatten','Streetballkorb','Fußballtore','Balancierholz','Reck','Kletterkamel']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Bausestraße / Groitzscher Straße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.311809,51.331622 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neulindenau,Alt-West",
+    "title":"Spielplatz Demmeringstraße",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Radiusstraße)','Bus: 80 (Haltestelle Radiusstraße)']",
+    "gaming_devices":"['Tischtennisplatte','Kletterpyramide']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Demmeringstraße / Radiusstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.371717,51.330766 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Süd,Mitte",
+    "title":"Spielplatz Floßplatz",
+    "local_traffic":"['Straßenbahn: 10, 11 (Haltestelle Hohe Straße)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Floßplatz",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.290887,51.327816 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönau,West",
+    "title":"Spielplatz Schönauer Park",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Parkallee)','Bus: 66 (Haltestelle Parkallee)']",
+    "gaming_devices":"['Kletterhaus mit  Rutsche','Schaukel','Kletternetz','Rutschpodest','Sandseilzug','Karussell','Seilbahn','Trampolin']",
+    "equipment":"['Schattenplätze','Spielwiese','Bänke','Sandspielfläche','Rodelhügel','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Schönauer Lachen",
+    "Wird geprüft durch":"René",
+    "Geprüft":"René"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.398042,51.334357 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Lene-Voigt-Park – Ballplatz",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Bus: 60 (Haltestelle Ostplatz)']",
+    "gaming_devices":"['Fussballore','Streetballkörbe']",
+    "equipment":"['Bänke','Fussballfeld','Streetballfeld','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Eilenburger Straße / Johannisallee",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.384702,51.332134 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Südost,Mitte",
+    "title":"Spielplatz Kanonenteich",
+    "local_traffic":"['Straßenbahn: 2, 9, 16 (Haltestelle Bayrischer Platz)']",
+    "gaming_devices":"['Klettergerüst']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Talstraße / Liebigstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.366397,51.333594 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Süd,Mitte",
+    "title":"Spielplatz Grassistraße",
+    "local_traffic":"['Bus: 89 (Haltestelle Mozartstraße)']",
+    "gaming_devices":"[' ','Doppelschaukel','Rutsch- und Kletterturm',' ']",
+    "equipment":"[' ','Findlinge','Schattenplätze','Bänke',' ','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Grassistraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.403238,51.333278 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Lene-Voigt-Park – Beachvolleyballplatz",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Bus: 60 (Haltestelle Ostplatz)']",
+    "gaming_devices":"['Volleyballfelder','Kletterwand']",
+    "equipment":"['Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Eilenburger Straße / Albert-Schweitzer-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.398084,51.334281 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Lene-Voigt-Park – Märchenplatz",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Bus: 60 (Haltestelle Ostplatz)']",
+    "gaming_devices":"['Holzschloss','Holzfigur Prinzessin','Kletterpyramide','Rutschbogen','Karussell']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Eilenburger Straße / Josephinenstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.440224,51.332918 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Ost,Mölkau",
+    "title":"Spielplatz Paunsdorfer Straße",
+    "local_traffic":"['Bus Linie 72, 73 (Haltestelle Anemonenweg)']",
+    "gaming_devices":"['Rutsche','Doppelschaukel','Klettergerüst','Wippe']",
+    "equipment":"['Bänke','Spielwiese','Schattenplätze','Sandspielfläche']",
+    "address":"Paunsdorfer Straße / Anemonenweg",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.327611,51.332496 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lindenau,Alt-West",
+    "title":"Spielplatz An der Helmholtzschule",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Henriettenstraße)']",
+    "gaming_devices":"['Mastpendel','Klettergerüst','Streetballplatz']",
+    "equipment":"['überdachter Sitzbereich','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Helmholtzstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.401417,51.333588 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Lene-Voigt-Park - Rutschplatz",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Bus: 60 (Haltestelle Ostplatz)']",
+    "gaming_devices":"['Hangrutschen','Kletterseil']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Eilenburger Straße / Rubensstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.401417,51.333588 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Lene-Voigt-Park - Wasserspiel",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Bus: 60 (Haltestelle Ostplatz)']",
+    "gaming_devices":"['Wasserpumpe','Holzstrecke mit Wasserlauf']",
+    "equipment":"['Sandspielfläche','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Eilenburger Straße / Rubensstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.401417,51.333588 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Lene-Voigt-Park – Kletterplatz",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Bus: 60 (Haltestelle Ostplatz)']",
+    "gaming_devices":"['Klettergerüst mit Ringen','Schaukel']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Eilenburger Straße / Rubensstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.326187,51.332897 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lindenau,Alt-West",
+    "title":"Spielplatz Henriettenpark",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Henriettenstraße)']",
+    "gaming_devices":"['Tischtennisplatte','Reifenschaukel','Rutsche','Kletterpodest','Stehkarussell','Balanciersteg','Streetballkorb','Skateranlage']",
+    "equipment":"['Spielwiese','Bänke','überdachter Sitzbereich','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Henriettenstraße / Endersstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed (unsicher)"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.361424,51.334935 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-West,Mitte",
+    "title":"Spielplatz Johannapark",
+    "local_traffic":"['Straßenbahn: 1, 2, 14 (Haltestelle Marschnerstraße)']",
+    "gaming_devices":"['Wippe','Rutsche','Spieltische','Balanciersteg']",
+    "equipment":"['Bänke','Spielwiese','Sandspielfläche','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Ferdinand-Lassalle-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.477788,51.33393 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz August-Bebel-Platz",
+    "local_traffic":"['Bus: 72, 172 (Haltestelle Arthur-Winkler-Straße)']",
+    "gaming_devices":"['Klettergerüst','Rutsche','Doppelschaukel']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Baumeister-Günther-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.403206,51.33498 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Reudnitzer Park - Skaterplatz ",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Breitestraße)','Bus: 70, 72 (Haltestelle Breitestraße)']",
+    "gaming_devices":"['Grindelemente','Streetballkorb']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Sigismundstraße / Charlottenstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.336251,51.333173 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lindenau,Alt-West",
+    "title":"Spielplatz Karl-Heine-Platz",
+    "local_traffic":"['Straßenbahn: 3, 14 (Haltestelle Felsenkeller)','Bus: 74 (Haltestelle Felsenkeller)']",
+    "gaming_devices":"['2 Tischtennisplatten','Streetballkorb','Fussballtor','Kletterhaus mit Kletterwand','Kletterhaus mit Rutsche','Sandtisch','Stufenreck']",
+    "equipment":"['Sandspielfläche','Rodelhügel','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Aurelienstraße / Siemeringstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.400815,51.333723 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Lene-Voigt-Park - Tischtennisplatz",
+    "local_traffic":"['Straßenbahn: 15 (Haltestelle Ostplatz)','Bus: 60 (Haltestelle Ostplatz)']",
+    "gaming_devices":"['Tischtennisplatten']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Eilenburger Straße / Reichpietschstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3231163,51.3349535 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Altlindenau,Alt-West",
+    "title":"Spielplatz Am Robert-Schumann-Gymnasium",
+    "local_traffic":"['Straßenbahn: 8, 15 (Haltestelle Henriettenstraße)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Demmeringstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed (unsicher)"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.404011,51.335397 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Reudnitzer Park – Kletterplatz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Breitestraße)','Bus: 70, 72 (Haltestelle Breitestraße)']",
+    "gaming_devices":"['Kletterhölzer','Klettersteine','Holzsteg']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Sigismundstraße / Wittstockstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.414364,51.334897 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Anger-Crottendorf,Ost",
+    "title":"Spielplatz Liselotte-Herrmann-Park",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Breite Straße)','Bus: 72, 73 (Haltestelle Martinstraße)']",
+    "gaming_devices":"['Kletter- und Rutschturm','Hängenetz','Matschtisch','Kletterseil','Tischtennisplatte']",
+    "equipment":"['Spielwiese','Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Zweinaundorfer Straße / Theodor-Neubauer-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3448213,51.3360348 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lindenau,Alt-West",
+    "title":"Spielplatz Palmengarten",
+    "local_traffic":"['Straßenbahn: 3, 7, 8, 15 (Haltestelle Angerbrücke)','Bus: 74, 130, 131 (Haltestelle Angerbrücke)']",
+    "gaming_devices":"['Kletterkugel','Rutschelefant','Kletterelemente']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"im Palmengarten",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed (unsicher)"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4780517,51.336494 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Engelsdorfer Park - Am Rodelhügel",
+    "local_traffic":"['Bus: 72, 172 (Haltestelle Arthur-Winkler-Straße)']",
+    "gaming_devices":"['Doppelschaukel']",
+    "equipment":"['Rodelhügel','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Arthur-Winkler-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4780517,51.336494 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Engelsdorfer Park - Ballplatz",
+    "local_traffic":"['Bus: 72, 172 (Haltestelle Arthur-Winkler-Straße)']",
+    "gaming_devices":"['Fußballtore','Streetballkorb']",
+    "equipment":"['Spielwiese','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Arthur-Winkler-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4780517,51.336494 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Engelsdorfer Park - Tischtennisplatz",
+    "local_traffic":"['Bus: 72, 172 (Haltestelle Arthur-Winkler-Straße)']",
+    "gaming_devices":"['Tischtennisplatten']",
+    "equipment":"['Schattenplätze','Spielwiese','Holzstämme','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Arthur-Winkler-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3683222,51.3366512 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-West,Mitte",
+    "title":"Spielplatz Plastikgarten",
+    "local_traffic":"['Straßenbahn: 2, 8, 14 (Haltestelle Neues Rathaus)','Bus: 89 (Haltestelle Neues Rathaus)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Schattenplätze','Sitzmauer','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Manetstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4824548,51.3368121 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Kleine Promenade",
+    "local_traffic":"['Bus: 172 (Haltestelle Opalstraße)']",
+    "gaming_devices":"['Holzwippe','Schaukel','Kletterstrecke']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Kleine Promenade / Bernsteinstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.323669,51.337802 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Altlindenau,Alt-West",
+    "title":"Spielplatz Queckstraße",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Georg-Schwarz-Straße)','Bus: 130, 131 (Haltestelle Georg-Schwarz-Straße)']",
+    "gaming_devices":"['Kletterstäbe','Balancierstämme','Klettersteine']",
+    "equipment":"['Naturpfad','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Queckstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.328775,51.337309 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Altlindenau,Alt-West",
+    "title":"Spielplatz Apostelstraße",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Georg-Schwarz-Straße/Merseburger Straße)','Bus: 130, 131 (Haltestelle Georg-Schwarz-Straße/Merseburger Straße)']",
+    "gaming_devices":"['Schaukel','Balancierstrecke','Holzelemente','Klettersteine','Spielkiste']",
+    "equipment":"['Schattenplätze','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Apostelstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.409727,51.338071 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Anger-Crottendorf,Ost",
+    "title":"Spielplatz Ramdohrscher Park",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Wiebelstraße)']",
+    "gaming_devices":"['Wippe','Kletterkombination','Schaukel','Rutsche','Tischtennisplatte']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Grüne Gasse",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.48414,51.337999 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Max-Reger-Straße",
+    "local_traffic":"['Bus: 172 (Haltestelle Opalstraße)']",
+    "gaming_devices":"",
+    "equipment":"['Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Max-Reger-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.398671,51.338037 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Reudnitz-Thonberg,Südost",
+    "title":"Spielplatz Stephaniplatz",
+    "local_traffic":"['Straßenbahn: 4, 7 (Haltestelle Gerichtsweg)','Bus: 70, 72, 73 (Haltestelle Reudnitz-Koehlerstraße)']",
+    "gaming_devices":"['Kletterhalbkugel','Kletterpyramide','Rutschturm','Kletterwand','Springnetz','Fußballplatz','Tischtennisplatz','Spielröhren']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Crusiusstraße / Stephaniplatz",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.5162131,51.3386604 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Althen-Kleinpösna,Ost",
+    "title":"Spielplatz Althener Anger",
+    "local_traffic":"['Bus: 73, 172 (Haltestelle Althener Anger)']",
+    "gaming_devices":"['Kletterturm','Rutsche','Doppelschaukel','Kletternetz','Wipptier','Kletterseil']",
+    "equipment":"['Schattenplätze','Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Prof. Andreas-Schubert-Straße / Althener Anger",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.418395,51.340648 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Volkmarsdorf,Ost",
+    "title":"Spielplatz Liselotte-Herrmann-Straße",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Edlichstraße)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Schattenplätze','Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Liselotte-Herrmann-Straße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3367,51.33857 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Altlindenau,Alt-West",
+    "title":"Spielplatz Henricistraße",
+    "local_traffic":"['Straßenbahn: 7, 8, 15 (Haltestelle Lindenauer Markt)','Bus: 74, 130, 131 (Haltestelle Lindenauer Markt)']",
+    "gaming_devices":"['Kletter- und Rutschturm','Streetballkorb','Schaukel']",
+    "equipment":"['Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Henricistraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.41529,51.339514 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Anger-Crottendorf,Ost",
+    "title":"Spielplatz Hanns-Eisler-Straße",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Wiebelstraße)']",
+    "gaming_devices":"['Kletter- und Rutschturm','Schaukel','Tischtennisplatten']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Hanns-Eisler-Straße / Schacherstraße ",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Plagwitz,Südwest",
+    "title":"Spielplatz Alte Gleisstraße",
+    "local_traffic":"['Straßenbahn: 14 (Haltestelle S-Bahnhof Plagwitz)','Bus: 60 (Haltestelle Naumburger Straße)']",
+    "gaming_devices":"['Tischtennisplatte','Doppelpendel','Spieltonnen']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Naumburger Straße / Höhe Zollschuppen",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.449456,51.39078 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Plaußig-Portitz,Nordost",
+    "title":"Spielplatz Alte Theklaer Straße",
+    "local_traffic":"['Bus: 83 (Haltestelle Alte Theklaer Straße)']",
+    "gaming_devices":"['Doppelschaukel','Rutsche','Karussell']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Alte Theklaer Straße (am Garagenplatz)",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.323686,51.369548 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wahren,Nordwest",
+    "title":"Spielplatz Am Auensee",
+    "local_traffic":"['Bus: 80 (Haltestelle Auensee)']",
+    "gaming_devices":"['Holzschiff','Reifenpendel','Klettermast','Steindino','Hängematte','Info','Ein Teilbereich des Holzschiffes muss aufgrund von Mängeln bis auf Weiteres gesperrt bleiben.']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','\\xd6ffentliche Parkplätze befinden sich am Hauptzugang zum Auensee.']",
+    "address":"östlicher Teil des Auensee",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönefeld-Ost,Nordost",
+    "title":"Spielplatz Am Garagenhof",
+    "local_traffic":"['Straßenbahn: 1 (Haltestelle Ossietzkystraße/Gorkistraße)']",
+    "gaming_devices":"['Fussballtore']",
+    "equipment":"['Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Heinrich-Büchner-Straße / am Garagenhof",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht  gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.347227,51.32671 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schleußig,Südwest",
+    "title":"Spielplatz An der AOK",
+    "local_traffic":"['Straßenbahn: 1, 2 (Holbeinstraße)']",
+    "gaming_devices":"['Fitnessgeräte','Balancierstrecke','Kletter- und Rutschturm','Fussballpaltz','Streetballplatz','Skaterbereich']",
+    "equipment":"['öffentliche Grill- und Feuerstelle','Bänke','Schattenplätze','Sandspielfläche','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Anton-Bruckner-Allee / im Clara-Zetkin-Park",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.403006,51.30605 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Marienbrunn,Süd",
+    "title":"Spielplatz An der Wendeschleife",
+    "local_traffic":"['Straßenbahn: 10, 16 (Haltestelle An der Märchenwiese)']",
+    "gaming_devices":"['2 Tischtennisplatten']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"An der Märchenwiese (Wendeschleife)",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Volkmarsdorf,Ost",
+    "title":"Spielplatz Dunkler Wald",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Wiebelstraße)']",
+    "gaming_devices":"['Tischtennisplatten']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Nathalienstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.428005,51.342916 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Sellerhausen-Stünz,Ost",
+    "title":"Spielplatz Emmauskirchplatz",
+    "local_traffic":"['Straßenbahn: 7, 8 (Haltestelle Emmausstraße)','Bus: 77 (Haltestelle Emmausstraße)']",
+    "gaming_devices":"['Drehscheibe','Wipptier']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Emmauskirchplatz",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.41969,51.32471 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Stötteritz,Südost",
+    "title":"Spielplatz Forstplatz im Stötteritzer Wäldchen",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Breslauer Straße)','Bus: 79 (Haltestelle Oberdorfstraße)']",
+    "gaming_devices":"['Rutsche','Karussell','Hangelstrecke','Balanciersteg']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"westlich der Oststraße / im Forst",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3730747,51.3396955 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Leutzsch,Alt-West",
+    "title":"Spielplatz Friesenstraße",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Wielandstraße)']",
+    "gaming_devices":"['Reifenkarussell','Klettersäule']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','Hinweis:','Die öffentlichen Parkplätze befinden sich außerhalb des Forstgebietes.']",
+    "address":"Friesenstraße / nahe Sportplatz am Waldrand",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.286277,51.355364 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Böhlitz-Ehrenberg,Alt-West",
+    "title":"Spielplatz Goetheplatz",
+    "local_traffic":"['Bus: 62 (Haltestelle Goetheplatz)']",
+    "gaming_devices":"['Kletter-und Rutschturm','Tischtennisplatte','Wippe']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Goetheplatz / Obere Mühlenstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.322082,51.301204 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Großzschocher,Südwest",
+    "title":"Spielplatz Huttenplatz",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Gerhard-Ellrodt-Straße)']",
+    "gaming_devices":"['Federkugel','Drehkegel']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Huttenstraße / Pfeilstaße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.36219,51.353794 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Nordwest,Mitte",
+    "title":"Spielplatz Louise-Otto-Peters-Platz",
+    "local_traffic":"['Straßenbahn: 12 (Haltestelle Am Zoo)']",
+    "gaming_devices":"['Holzdrachen','Holzkarussell','Elefantenrutsche','Holzungeheuer','Findlinge']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Zöllnerweg / Leibnitzweg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.31429,51.290747 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Großzschocher,Südwest",
+    "title":"Spielplatz Naturbad Südwest",
+    "local_traffic":"['Straßenbahn: 3 (Haltestelle Wasserwerk Windorf)']",
+    "gaming_devices":"['Kletterflugzeuge','Reck']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Dieskaustraße (Westseite vom Naturbad)",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.415381,51.33957 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Anger-Crottendorf,Ost",
+    "title":"Spielplatz Krönerstraße“;['Straßenbahn: 7 (Haltestelle Wiebelstraße)'];['Tischtennisplatte','Volleyballfeld','Fußballfeld'];['Spielwiese','Bänke','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden'];Krönerstraße;51.3397809;12.4152221\nLeipzig;Anger-Crottendorf,Ost;Spielplatz Krönerstraße“",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Wiebelstraße)']",
+    "gaming_devices":"['Tischtennisplatte','Volleyballfeld','Fußballfeld']",
+    "equipment":"['Spielwiese','Bänke','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Krönerstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.324971,51.340003 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Altlindenau,Alt-West",
+    "title":"Spielplatz Georgplatz",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Wielandstraße)']",
+    "gaming_devices":"['Kletter- und Rutschpodest']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Spittastraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.404356,51.340432 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neustadt-Neuschönefeld,Ost",
+    "title":"Spielplatz Bernhardiplatz",
+    "local_traffic":"['Straßenbahn: 4, 7 (Haltestelle Koehlerstraße)','Bus: 70, 72, 73 (Haltestelle Koehlerstraße)']",
+    "gaming_devices":"['Kletter- und Rutschturm','Tischtennisplatte','Streetballkorb']",
+    "equipment":"['Findlinge','Schattenplätze','Bänke','Sandspielfläche','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Lilienstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.322676,51.340331 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Altlindenau,Alt-West",
+    "title":"Spielplatz Gellertplatz",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Wielandstraße)']",
+    "gaming_devices":"['Tischtennisplatte','Klettersteine','Kletterwand']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Betonliege','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Wielandstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.485301,51.3405539 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Opalstraße",
+    "local_traffic":"['Bus: 172 (Haltestelle Opalstraße)']",
+    "gaming_devices":"['Holzpodest']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Opalstraße / Gaswerksweg",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.479113,51.339961 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Malachitstraße",
+    "local_traffic":"['Bus: 172 (Haltestelle Opalstraße)']",
+    "gaming_devices":"['Kletterdrachen','Rutsche']",
+    "equipment":"['Bänke',' ','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Malachitstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"unsicher"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3218227,51.3411699 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Altlindenau,Alt-West",
+    "title":"Spielplatz Großmannplatz",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Wielandstraße)']",
+    "gaming_devices":"['Tischtennisplatten','Rutsche','Holzstämme','Findlinge']",
+    "equipment":"['Schattenplätze','Spielwiese','Bänke','Versteckflächen','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Großmannstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3766734,51.3414038 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum,Mitte",
+    "title":"Spielplatz Labyrinth",
+    "local_traffic":"['Straßenbahn: 1, 7, 4, 12, 15, 3, 10, 16, 11, 14, 9 (Haltestelle Hauptbahnhof)','Bus: 89 (Haltestelle Reichsstraße)']",
+    "gaming_devices":"['Kletterstein','Balancierseile','Spielturm','Trampolin','Spielhäuser',' ']",
+    "equipment":"['Labyrinth','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Reichsstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4876091,51.3414736 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz An der Grundschule",
+    "local_traffic":"['Bus: 72 (Haltestelle Klempererstraße)']",
+    "gaming_devices":"['Klettergerüst','Rutsche','Kletternetz','Doppelschaukel']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"An der Grundschule",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4001048,51.3418614 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neustadt-Neuschönefeld,Ost",
+    "title":"Spielplatz Klasingstraße",
+    "local_traffic":"['Straßenbahn: 4, 7 (Haltestelle Gerichtsweg)']",
+    "gaming_devices":"['Tischtennisplatten','Wipproller','Kletterbahn']",
+    "equipment":"['Schattenplätze','Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Klasingstraße/Reclamstraße",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4283958,51.3427021 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Sellerhausen-Stünz,Ost",
+    "title":"Spielplatz Emmausstraße",
+    "local_traffic":"['Straßenbahn: 7, 8 (Haltestelle Emmausstraße)','Bus: 77 (Haltestelle Emmausstraße)']",
+    "gaming_devices":"['Rutsch- und Kletterturm','Tischtennisplatten']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Emmausstraße",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3999158,51.3432898 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neustadt-Neuschönefeld,Ost",
+    "title":"Spielplatz Elsapark",
+    "local_traffic":"['Straßenbahn: 1, 3, 8 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)','Bus: 72, 73 (Haltestelle Elsastraße)']",
+    "gaming_devices":"['Tischtennisplatte','Streetballplatz','Kletterturm','Rutsche','Matschtisch']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Elsastraße",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4029903,51.3434382 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neustadt-Neuschönefeld,Ost",
+    "title":"Spielplatz Stadtteilpark Rabet - Ball- und Skaterplatz",
+    "local_traffic":"['Straßenbahn: 1, 3, 8 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)','Bus: 70 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)']",
+    "gaming_devices":"['Tischtennisplatten','Skaterplatz','Fußballfeld','Streetballplatz','Beachballplatz']",
+    "equipment":"['Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Rabet",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4029903,51.3434382 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neustadt-Neuschönefeld,Ost",
+    "title":"Spielplatz Stadtteilpark Rabet - Holzspielplatz",
+    "local_traffic":"['Straßenbahn: 1, 3, 8 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)','Bus: 70 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)']",
+    "gaming_devices":"['Balancierholz','Holzwippe','Hangelstrecke']",
+    "equipment":"['Spielwiese','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Rabet",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4029903,51.3434382 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neustadt-Neuschönefeld,Ost",
+    "title":"Spielplatz Stadtteilpark Rabet - Piratenplatz Bounty",
+    "local_traffic":"['Straßenbahn: 1, 3, 8 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)','Bus: 70 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)']",
+    "gaming_devices":"['Kletternetz','Schiffswrack','Hangrutsche','Würfel','Drehscheibe','Reifenpendel','Karussell']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Laufstrecke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Rabet",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4029903,51.3434382 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neustadt-Neuschönefeld,Ost",
+    "title":"Spielplatz Stadtteilpark Rabet - Schaukelplatz",
+    "local_traffic":"['Straßenbahn: 1, 3, 8 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)','Bus: 70 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)']",
+    "gaming_devices":"['Schaukel']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Rabet",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.2745964,51.3434498 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Burghausen-Rückmarsdorf,Alt-West",
+    "title":"Spielplatz An den Linden",
+    "local_traffic":"['Bus: 130, 131 (Haltestelle Zum Bahnhof)']",
+    "gaming_devices":"['Doppelschaukel','Kletterturm','Hängebrücke','2 Rutschen','Wippe']",
+    "equipment":"['Pavillon','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"An den Linden / Tucholskystraße",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4090467,51.3444654 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Volkmarsdorf,Ost",
+    "title":"Spielplatz Stadtplatz",
+    "local_traffic":"['Straßenbahn: 1, 3, 8 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)','Bus: 70 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)']",
+    "gaming_devices":"['Klettergerüst','Tischtennisplatte']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Mariannenstraße / Elisabethstraße",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.42705,51.3448713 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Sellerhausen-Stünz,Ost",
+    "title":"Spielplatz Jugendclub – Rückseite",
+    "local_traffic":"['Bus: 77 (Haltestelle Püchauer Straße)']",
+    "gaming_devices":"['Geräteplatz - Trimm \\u2013 Dich','Drehscheibe','Schaukel']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Püchauer Straße",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.42705,51.3448713 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Sellerhausen-Stünz,Ost",
+    "title":"Spielplatz Jugendclub – Vorderseite",
+    "local_traffic":"['Bus: 77 (Haltestelle Püchauer Straße)']",
+    "gaming_devices":"['Kletterwand','Tischtennisplatte','Streetballplatz']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Püchauer Straße ",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3947384,51.3464047 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neustadt-Neuschönefeld,Ost",
+    "title":"Spielplatz Schulze-Delitzsch-Straße",
+    "local_traffic":"['Straßenbahn: 1, 3, 8 (Haltestelle Einertstraße)']",
+    "gaming_devices":"['Wippe','Kletterturm','Rutsche','Kletterwand','Matschtisch','Kletterpodest','Fußballplatz','Tischtennisplatte']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Schulze-Delitzsch-Straße / Rosa-Luxemburg-Straße",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4511293,51.3475789 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Paunsdorf,Ost",
+    "title":"Spielplatz Döllingstraße",
+    "local_traffic":"['Straßenbahn: 7, 8 (Haltestelle Theodor-Heuss-Straße)','Bus: 79, 90 (Haltestelle Theodor-Heuss-Straße)']",
+    "gaming_devices":"['Tischtennisplatte','Rutschturm']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Döllingstraße",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4038307,51.3476367 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neustadt-Neuschönefeld,Ost",
+    "title":"Spielplatz Neustädter Markt - Ostseite",
+    "local_traffic":"['Straßenbahn: 1, 3, 8 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)']",
+    "gaming_devices":"['Kletterhaus','Rutsche','Kletternetz']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Neustädter Markt",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4038307,51.3476367 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Neustadt-Neuschönefeld,Ost",
+    "title":"Spielplatz Neustädter Markt",
+    "local_traffic":"['Straßenbahn: 1, 3, 8 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)','Bus: 70 (Haltestelle Hermann-Liebmann-Straße/Eisenbahnstraße)']",
+    "gaming_devices":"['Kletterpilze']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Neustädter Markt ",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4928504,51.3479408 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Arnoldplatz - Ballplatz",
+    "local_traffic":"['Bus: 73, 172, 175 (Haltetstelle Sabinenstraße)']",
+    "gaming_devices":"['Torwand']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Arnoldplatz ",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4928504,51.3479408 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Engelsdorf,Ost",
+    "title":"Spielplatz Arnoldplatz - Kletterplatz",
+    "local_traffic":"['Bus: 73, 172, 175 (Haltestelle Sabinenstraße)']",
+    "gaming_devices":"['Kletterturm','Rutsche','Holzhaus']",
+    "equipment":"['Sandspielfläche','Spielwiese','Spielhügel','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Arnoldplatz",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4802158,51.3481509 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Paunsdorf,Ost",
+    "title":"Spielplatz Sommerfelder Weg",
+    "local_traffic":"['Straßenbahn: Linie 3, 7 (Haltestelle Paunsdorf Center)','Bus: 90 (Haltestelle Paunsdorf Center)']",
+    "gaming_devices":"['Balancierbalken','Kletterturm']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Sommerfelder Weg",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.350589,51.347965 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Nordwest,Mitte",
+    "title":"Spielplatz Robert-Koch-Platz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Am Mückenschlößchen)']",
+    "gaming_devices":"['Schaukeln','Klettersteine','Klettergerüst mit Netz','Wellenbahn','Holzfiguren']",
+    "equipment":"['Spielwiese','Schatten','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Eitingonstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.353163,51.348157 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Nordwest,Mitte",
+    "title":"Spielplatz Am Mückenschlößchen",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Am Mückenschlößchen)']",
+    "gaming_devices":"['Rutschkugel']",
+    "equipment":"['Bänke','Schatten','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Mückenschlößchen",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.315471,51.347856 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Leutzsch,Alt-West",
+    "title":"Spielplatz Am Wasserschloß",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Rathaus Leutzsch)','Bus: 67 (Haltestelle Rathaus Leutzsch)']",
+    "gaming_devices":"['Steinspirale','Streetballkorb']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Wasserschloß",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed (unsicher)"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.269765,51.346222 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Burghausen-Rückmarsdorf,Alt-West",
+    "title":"Spielplatz Am Ochsenweg",
+    "local_traffic":"['Bus: 62, 130, 131 (Haltestelle Löwencenter)']",
+    "gaming_devices":"['Rutsche','Wippe','Schaukel']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Ochsenweg",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.362206,51.353768 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Nordwest,Mitte",
+    "title":"Spielplatz Herrenallee",
+    "local_traffic":"['Straßenbahn: 12 (Haltestelle Fritz-Seger-Straße)']",
+    "gaming_devices":"['Kletterturm','Klettersteine','Naturelemente']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','Die öffentlichen Parkplätze befinden sich im nahegelegenen Wohnviertel.']",
+    "address":"Herrenallee im Rosental",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4025717,51.3516795 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönefeld-Abtnaundorf,Nordost",
+    "title":"Spielplatz Mariannenpark - Holzspielplatz",
+    "local_traffic":"['Straßenbahn: 1 (Haltestelle Stannebeinplatz)','Bus: 90 (Haltestelle Mariannenpark)']",
+    "gaming_devices":"['Kletter- und Rutschturm','Schaukel','Stufenreck','Wippe','Hängematte']",
+    "equipment":"['Sandspielfläche','Spielwiese','Rodelhügel','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Schönefelder Allee / Rohrteichstraße",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4025717,51.3516795 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönefeld-Abtnaundorf,Nordost",
+    "title":"Spielplatz Mariannenpark - Jugendplatz",
+    "local_traffic":"['Straßenbahn: 1 (Haltestelle Stannebeinplatz)','Bus: 90 (Haltestelle Mariannenpark)']",
+    "gaming_devices":"['Klettergerüst','Tischtennisplatten']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Rohrteichstraße ",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.308484,51.352798 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Leutzsch,Alt-West",
+    "title":"Spielplatz Heimteichstraße",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Philipp-Reis-Straße)']",
+    "gaming_devices":"['Tischtennisplatten','Klettergerüst','Rutsche','Schaukel','Flüsterkugel']",
+    "equipment":"['Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Heimteichstraße / Gaußstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.260481,51.352511 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Burghausen-Rückmarsdorf,Alt-West",
+    "title":"Spielplatz Bienitzstraße",
+    "local_traffic":"['Bus: 62 (Haltestelle Burghausen)']",
+    "gaming_devices":"['Kletterturm','Rutschturm','Wippe','Doppelschaukel']",
+    "equipment":"['Findlinge','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Bienitzstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3757,51.354887 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Nord,Mitte",
+    "title":"Spielplatz Balzacstraße",
+    "local_traffic":"['Straßenbahn: 10, 11, 16 (Haltestelle Chausseehaus)']",
+    "gaming_devices":"['Hinweis:','Aufgrund von Umbauarbeiten sind derzeit keine Spielgeräte vorhanden. Der Umbau ist für das Frühjahr 2014 vorgesehen.','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "equipment":"",
+    "address":"Balzacstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.292608,51.355579 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Böhlitz-Ehrenberg,Alt-West",
+    "title":"Spielplatz Lessingplatz",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Südstraße)','Bus: 62 (Haltestelle Südstraße)']",
+    "gaming_devices":"['Doppelschaukel','Sitzkarussell','Kletterelement Spagettini']",
+    "equipment":"['Bänke','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Heinrich-Heine-Straße / Südstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.283351,51.356277 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Böhlitz-Ehrenberg,Alt-West",
+    "title":"Spielplatz Gartengrund';['Straßenbahn: 7 (Haltestelle Ludwig-Jahn-Straße)','Bus: 62 (Haltestelle Breitestraße)'];['Rutschturm','Drehscheibe'];['Findlinge','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden'];Gartengrund / Luppenaue;51.3548629;12.2827514\nLeipzig;Böhlitz-Ehrenberg,Alt-West;Spielplatz Gartengrund'",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Ludwig-Jahn-Straße)','Bus: 62 (Haltestelle Breitestraße)']",
+    "gaming_devices":"['Rutschturm','Drehscheibe']",
+    "equipment":"['Findlinge','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Gartengrund / Luppenaue",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.290717,51.358803 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Böhlitz-Ehrenberg,Alt-West",
+    "title":"Spielplatz Bielagarten",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Südstraße)','Bus: 62 (Haltestelle Südstraße)']",
+    "gaming_devices":"['Streetballkorb','Tischtennisplatte']",
+    "equipment":"['Schattenplätze','Bänke','Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Bielastraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.373195,51.356927 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Zentrum-Nord,Mitte",
+    "title":"Spielplatz Richterplatz",
+    "local_traffic":"['Straßenbahn: 10, 11, 16 (Haltestelle Chausseehaus)']",
+    "gaming_devices":"['Tischtennisplatten','Wippscheibe','Gurtsteg','Schaukel']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Trufanowstraße / Frickestraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.457214,51.358249 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Paunsdorf,Ost",
+    "title":"Spielplatz Grüner Bogen - Heiterer Blick';['Straßenbahn: 7, 8 (Haltestelle Ahornstraße)'];['Rutschturm','Balancier- und Kletterhölzer','Doppelschaukel','Gurtsteg','Kletternetz'];['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden'];Höhe Hainbuchenstraße;51.3569328;12.4567424\nLeipzig;Paunsdorf,Ost;Spielplatz Grüner Bogen - Heiterer Blick'",
+    "local_traffic":"['Straßenbahn: 7, 8 (Haltestelle Ahornstraße)']",
+    "gaming_devices":"['Rutschturm','Balancier- und Kletterhölzer','Doppelschaukel','Gurtsteg','Kletternetz']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Höhe Hainbuchenstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 51.35902,51.35902 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Paunsdorf,Ost",
+    "title":"Spielplatz Grüner Bogen – Jugendtreff",
+    "local_traffic":"['Straßenbahn: 7, 8 (Haltestelle Ahornstraße)']",
+    "gaming_devices":"['Tischtennisplatte','Streetballkorb']",
+    "equipment":"['Feuerplatz','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Höhe Hainbuchenstraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4756406,51.3598675 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Heiterblick,Ost",
+    "title":"Spielplatz Goldene Hufe - Kletterplatz",
+    "local_traffic":"['Straßenbahn: 3,7,8 (Haltestelle Paunsdorf-Nord)']",
+    "gaming_devices":"['Kletterhaus','Doppelschaukel','Rutsche','Wipptier']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Goldene Hufe",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4756406,51.3598675 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Heiterblick,Ost",
+    "title":"Spielplatz Goldene Hufe - Seilplatz",
+    "local_traffic":"['Straßenbahn: 3,7,8 (Haltestelle Paunsdorf-Nord)']",
+    "gaming_devices":"['Seilzugkombination aus Holz']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Goldene Hufe",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.418468,51.361297 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönefeld-Abtnaundorf,Nordost",
+    "title":"Spielplatz Rotheplatz",
+    "local_traffic":"['Straßenbahn: 1 (Haltestelle Ossietzkystraße/Gorkistraße)']",
+    "gaming_devices":"['Kletter-/Rutschturm','Schaukel','Tischtennisplatte','Reck','Federsitz']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Abtnaundorfer Straße / Lazarusstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.358733,51.357865 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Gohlis-Süd,Nord",
+    "title":"Spielplatz Schillerhain",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Stallbaumstraße)']",
+    "gaming_devices":"['Kletterturm','Rutschturm','Steintiere','Tischtennisplatte']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Platnerstraße / Stallbaumstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.387652,51.360534 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Eutritzsch,Nord",
+    "title":"Spielplatz Hohmannplatz",
+    "local_traffic":"['Straßenbahn: 16 (Haltestelle Wilhelminenstraße)','Bus: 90 (Haltestelle Theresienstraße)']",
+    "gaming_devices":"['Doppelschaukel','Kletterwand','Kletternetz']",
+    "equipment":"['Bänke','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Hohmannstraße / Theresienstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.296554,51.364252 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wahren,Nordwest",
+    "title":"Spielplatz Am alten Forsthaus",
+    "local_traffic":"['Straßenbahn: 7 (Haltestelle Südstraße)','Bus: 62 (Haltestelle Südstraße)']",
+    "gaming_devices":"['Hangelgerüst','Stehwippe','Sitzkarussell','Schaukel','Kletterholz','Gewichtdrücken']",
+    "equipment":"['Sitzgruppe aus Holz','Schattenplätze','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Zum Waldbad / Kilometerweg",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.382258,51.367928 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Eutritzsch,Nord",
+    "title":"Spielplatz Elefantenplatz im Arthur-Bretschneider-Park",
+    "local_traffic":"['Straßenbahn: 12 (Haltestelle Gottschallstraße)','Straßenbahn: 16 (Haltestelle Eutritzsch Markt)','Bus: 85 (Haltestelle Gottschallstraße)','Bus: 90 (Haltestelle Kleiststraße)']",
+    "gaming_devices":"['Elefantenrutsche','Stehkarussell','Wippe']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Gottschallstraße / Geibelstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.371283,51.365217 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Gohlis-Mitte,Nord",
+    "title":"Spielplatz Freiligrathplatz",
+    "local_traffic":"['Straßenbahn: 12 (Haltestelle S-Bahnhof Gohlis)','S-Bahn : S1, S3 (Haltestelle Gohlis)']",
+    "gaming_devices":"['Kletter- und Rutschturm','Tischtennisplatte']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Dietzgenstraße / Benedixstraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.381829,51.366349 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Eutritzsch,Nord",
+    "title":"Spielplatz Drei Bären - Arthur-Bretschneider-Park",
+    "local_traffic":"['Straßenbahn: 16 (Haltestelle Eutritzsch Zentrum)','Straßenbahn: 12 (Haltestelle Virchow-/ Coppistraße)','Bus: 85 (Haltestelle Virchow-/ Coppistraße)','Bus: 90 (Haltestelle Kleiststraße)']",
+    "gaming_devices":"['Steinbären','Doppelschaukel']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Geibelstraße / Coppistraße",
+    "Wird geprüft durch":"Pascal",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.361753,51.367467 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Gohlis-Mitte,Nord",
+    "title":"Spielplatz Ludwig-Beck-Straße",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Coppiplatz)','S-Bahn: S10 (Haltestelle Coppiplatz)']",
+    "gaming_devices":"['Rutschturm','Balancierbalken','Kletterturm']",
+    "equipment":"['Schattenplätze','Spielwiese','Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Ludwig-Beck-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.345566,51.367696 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Möckern,Nordwest",
+    "title":"Spielplatz Kirchplatz Möckern",
+    "local_traffic":"['Straßenbahn: 10, 11 (Haltestelle Dantestraße)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Spielwiese','Bänke','Findlinge','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Georg-Schuhmann-Straße / Dantestraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.416429,51.369383 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Schönefeld-Abtnaundorf,Nordost",
+    "title":"Spielplatz Abtnaundorfer Park",
+    "local_traffic":"['Bus: 70, 79 (Haltestelle Heiterblickstraße)']",
+    "gaming_devices":"['Kletter- und Rutschturm','Kletterstäbe','Gurtsteg','Schaukel','Reck']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Abtnaundorfer Straße / Heiterblickstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4254271,51.3694767 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Thekla,Nordost",
+    "title":"Spielplatz Naturbad Nordost - Volleyballplatz",
+    "local_traffic":"['Bus: 70 (Haltestelle Sosaer Straße)','Bus: 79 (Haltestelle Lidicestraße)']",
+    "gaming_devices":"['Volleyballfeld']",
+    "equipment":"['Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Theklaer Straße",
+    "Wird geprüft durch":"",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3710897,51.369546 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Gohlis-Mitte,Nord",
+    "title":"Spielplatz Heinrich-Budde-Platz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Coppiplatz)','Straßenbahn: 12 (Haltestelle Virchow-/Coppistraße)','Bus: 90 (Haltestelle Coppiplatz)']",
+    "gaming_devices":"['Klettertürme','Rutschturm','Balancierstäbe','Hängematte']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Heinrich-Budde-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.361638,51.369648 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Gohlis-Mitte,Nord",
+    "title":"Spielplatz Platz des 20. Juli 1944",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Coppiplatz)','S-Bahn: S10 (Haltestelle Coppiplatz)']",
+    "gaming_devices":"['Tischtennisplatten']",
+    "equipment":"['Spielwiese','Sandspielfläche','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Platz des 20. Juli 1944",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4686254,51.3700369 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Böhlitz-Ehrenberg,Alt-West",
+    "title":"Spielplatz Johannes-Weyrauch-Platz",
+    "local_traffic":"['Straßenbahn: 4 (Haltestelle Barneckerstraße)','Bus: 62 (Haltestelle Südstraße)']",
+    "gaming_devices":"['Wippe','Tischtennisplatte','Federsitz','Klettergerüst']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Pestalozzistraße / Leipziger Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.4261777,51.3715597 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Thekla,Nordost",
+    "title":"Spielplatz Naturbad Nordost - Holzspielplatz",
+    "local_traffic":"['Straßenbahn: 9 (Haltestelle Thekla)','Bus: 70, 80 (Haltestelle Thekla)']",
+    "gaming_devices":"['Holzklettergerüst','Rutsche','Reifenpendel','Reck']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Kiebitzstraße / am Naturbad Nordost",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.317075,51.37496 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wahren,Nordwest",
+    "title":"Spielplatz Schillerplatz",
+    "local_traffic":"['Straßenbahn: 11 (Haltestelle Pittlerstraße)']",
+    "gaming_devices":"",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Auenseestraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.299003,51.378294 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lützschena-Stahmeln,Nordwest",
+    "title":"Spielplatz Stahmelner Straße",
+    "local_traffic":"['Straßenbahn: 11 (Haltestelle Stahmeln)']",
+    "gaming_devices":"['Doppelschaukel','Kletter- und Rutschturm','Kreidetafel']",
+    "equipment":"['Spielwiese','Bänke','Sandspielfläche','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Stahmelner Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.405358,51.37686 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Mockau-Nord,Nordost",
+    "title":"Spielplatz Friedrichshafner Straße",
+    "local_traffic":"['Bus: 70 (Haltestelle Schildberger Weg)','Bus: 80 (Haltestelle Rosenowstraße)']",
+    "gaming_devices":"['Hinweis:','Bogenbrücke','Hängematte','Pyramidenturm','Pendelschwinger']",
+    "equipment":"['Spielwiese','Bänke','Sandspielfläche','Rodelhügel','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Friedrichshafner Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.30344,51.376378 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lützschena-Stahmeln,Nordwest",
+    "title":"Spielplatz Stahmelner Anger",
+    "local_traffic":"['Straßenbahn: 11 (Haltestelle Stahmeln)']",
+    "gaming_devices":"['Rutsch- und Kletterturm']",
+    "equipment":"['Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Stahmelner Anger",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3305202,51.3773439 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Möckern,Nordwest",
+    "title":"Spielplatz Bürgerpark Sternsiedlung",
+    "local_traffic":"['Bus: 80, 90 (Haltestelle Sternsiedlung Nord)','S-Bahn: S10 (Haltestelle Slevogtstraße)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"[' ','Spielwiese mit Hügeln','Findlinge',' ','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Defoestraße / Travniker Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.44772,51.380769 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Thekla,Nordost",
+    "title":"Spielplatz Hotherplatz – Erlasiedlung",
+    "local_traffic":"['Bus: 81, 82 (Haltestelle Wodanstraße)']",
+    "gaming_devices":"['Tischtennisplatte','Reifenschaukel']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Hotherstraße / Donarstraße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.335761,51.381185 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wahren,Nordwest",
+    "title":"Spielplatz Gustav-Schmoller-Straße",
+    "local_traffic":"['Bus: 87, 88 (Haltestelle Zeisigweg)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Holzpavillon','Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Gustav-Schmoller-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.461,51.3812373 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Plaußig-Portitz,Nordost",
+    "title":"Spielplatz Parkstadt 2000",
+    "local_traffic":"['Bus: 81, 82 (Haltestelle Krätzbergstraße)']",
+    "gaming_devices":"['Wippelement']",
+    "equipment":"['Sandspielfläche','Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Werfelstraße ",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":""
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.458336,51.381211 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Plaußig-Portitz,Nordost",
+    "title":"Spielplatz Parkstadt 2000 – Drachen",
+    "local_traffic":"['Bus: 81, 82 (Haltestelle Krätzbergstraße)']",
+    "gaming_devices":"['Kletterdrachen','Kletterpyramiden','Rutschen']",
+    "equipment":"['Spielwiese','Bänke','separater Sitzbereich','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Künstlerbogen",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.2700194,51.384042 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lützschena-Stahmeln,Nordwest",
+    "title":"Spielplatz Am Brunnen",
+    "local_traffic":"['Straßenbahn: 11 (Haltestelle Freirodaer Weg)']",
+    "gaming_devices":"['Tischtennisplatte','Doppelschaukel','Klettergerüst','Stehwippe','Balancierbalken','Reck']",
+    "equipment":"['Schattenplätze','Sandspielfläche','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Brunnen / Elsterberg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.459586,51.386119 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Plaußig-Portitz,Nordost",
+    "title":"Spielplatz Sandgrube Portitz",
+    "local_traffic":"['Bus: 81, 82 (Haltestelle Krätzbergstraße)']",
+    "gaming_devices":"['Tischtennisplatten']",
+    "equipment":"['Spielwiese','Bänke','Sandspielfläche','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Sandgrubenweg / Hügelweg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3842565,51.3850188 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Eutritzsch,Nord",
+    "title":"Spielplatz Krostitzer Weg",
+    "local_traffic":"['Straßenbahn: 16 (Klinikum St. Georg)']",
+    "gaming_devices":"['Tischtennisplatte']",
+    "equipment":"['Spielwiese','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Krostitzer Weg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.374751,51.387581 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wiederitzsch,Nord",
+    "title":"Spielplatz Landschaftspark Wiederitzsch - Sandspielplatz",
+    "local_traffic":"['Straßenbahn: 16 (Haltestelle Dachauer Straße)','Bus: 87 (Haltestelle Dachauer Straße)']",
+    "gaming_devices":"['Wipptier','Holzhaus','Sandspieltisch']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Höhe Ebereschenweg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.374573,51.388628 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wiederitzsch,Nord",
+    "title":"Spielplatz Landschaftspark Wiederitzsch - Kletterplatz",
+    "local_traffic":"['Straßenbahn: 16 (Haltestelle Dachauer Straße)','Bus: 87 (Haltestelle Dachauer Straße)']",
+    "gaming_devices":"['Doppelschaukel','Tischtennisplatte','Wippe','Kletterturm','Hängematte','Kletterröhre','Rutschturm','Streetballplatz']",
+    "equipment":"['Sandspielfläche','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Akazienweg",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.321689,51.390273 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lindenthal,Nordwest",
+    "title":"Spielplatz Lewienstraße",
+    "local_traffic":"['Bus: 90 (Haltestelle Rudolf-Breitschneider-Straße)']",
+    "gaming_devices":"['Rutsch- und Kletterhaus','Wippe','Wipptier']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Lewienstraße / Rosestraße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.361473,51.391872 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wiederitzsch,Nord",
+    "title":"Spielplatz Am Haferring",
+    "local_traffic":"['Straßenbahn: 16 (Haltestelle Dachauer Straße)','Bus: 87 (Haltestelle Dachauer Straße)']",
+    "gaming_devices":"['Tischtennisplatte','Kletter- und Rutschturm','Schaukel','Wipptier']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Am Haferring",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.333516,51.391904 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lindenthal,Nordwest",
+    "title":"Spielplatz An der Schule",
+    "local_traffic":"['Bus: 87, 88, 90 (Haltestelle An der Schule)']",
+    "gaming_devices":"['Drehscheibe','Rodelhügel','Streetballplatz']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"An der Schule",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3829931,51.3978664 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wiederitzsch,Nord",
+    "title":"Spielplatz Georg-Herwegh-Straße",
+    "local_traffic":"['Straßenbahn: 16 (Haltestelle Georg-Herwegh-Straße)']",
+    "gaming_devices":"['Kletterpyramide']",
+    "equipment":"['Spielwiese','Bänke','Parkmöglichkeit:','öffentliche P+R Parkplätze an der Georg-Herwegh-Straße vorhanden']",
+    "address":"Georg-Herwegh-Straße",
+    "Wird geprüft durch":"Andy",
+    "Geprüft":"nicht gefunden"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.3758013,51.398782 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wiederitzsch,Nord",
+    "title":"Spielplatz Schmuckplatz",
+    "local_traffic":"['Straßenbahn: 16 (Haltestelle Wiederitzsch-Mitte)']",
+    "gaming_devices":"['Tischtennisplatte','Kletterturm','Rutsche','Wipptier','Laufrolle','Wippe','Reck']",
+    "equipment":"['Spielwiese','Schattenplätze','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Stentzlerstraße / Hermann-Keller-Straße",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"nicht sicher"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.372325,51.402848 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Wiederitzsch,Nord",
+    "title":"Spielplatz Salbeiweg",
+    "local_traffic":"['Bus: 87 (Haltestelle Salzhandelsstraße)']",
+    "gaming_devices":"['Rutsch- und Kletterturm','kleines Rutschhaus','Malwand','Minisitzgruppe']",
+    "equipment":"['Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Salbeiweg",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.348583,51.405718 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Lindenthal,Nordwest",
+    "title":"Spielplatz Park Breitenfeld",
+    "local_traffic":"['Bus: 87, 88 (Haltestelle Parkring)']",
+    "gaming_devices":"['Fussballplatz','Volleyballfeld','Streetballplatz','Wipptier','Wippe','Kletternetz','Sprossenwand']",
+    "equipment":"['Bänke','Spielwiese','Schattenplätze','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Parkring",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+       "type": "Point",
+       "coordinates":  [ 12.423214,51.420694 ]
+    },
+    "properties": {
+    "town":"Leipzig",
+    "district":"Seehausen,Nord",
+    "title":"Spielplatz Gutsweg",
+    "local_traffic":"['Bus: 86 (Haltestelle Göbschelwitz)']",
+    "gaming_devices":"['Kletterrondell','Röhre']",
+    "equipment":"['Sandspielflächen','Spielwiese','Bänke','Parkmöglichkeit:','öffentliche Parkplätze vorhanden']",
+    "address":"Gutsweg ",
+    "Wird geprüft durch":"Robert",
+    "Geprüft":"fixed"
+    }
+  }
+]
+}

--- a/utils/compare-geojson-frontend/Leaflet.TileLayer.HERE.html
+++ b/utils/compare-geojson-frontend/Leaflet.TileLayer.HERE.html
@@ -1,0 +1,163 @@
+<!-- 
+* Source: https://ivansanchez.gitlab.io/Leaflet.TileLayer.HERE/demo.html and https://gitlab.com/IvanSanchez/Leaflet.TileLayer.HERE
+* This page is an internal tool to compare kidsle-data with overpass-files
+* insert appid and appcode to get unlimited tiles from nokia here
+-->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+	<link href="https://leafletjs-cdn.s3.amazonaws.com/content/leaflet/master/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="https://leafletjs-cdn.s3.amazonaws.com/content/leaflet/master/leaflet.js"></script>
+	<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="
+		crossorigin="anonymous"></script>
+	<script src="https://ivansanchez.gitlab.io/Leaflet.TileLayer.HERE/leaflet-tilelayer-here.js"></script>
+
+	<meta charset="utf-8">
+	<title>Leaflet.TileLayer.HERE demo</title>
+	<style>
+		body {
+			margin: 0;
+		}
+		
+		#map {
+			width: 100vw;
+			height: 100vh;
+		}
+	</style>
+</head>
+
+<body>
+	<div id='map'></div>
+
+	<script>
+
+  
+  		var json_kidsle_corrected = "";
+		$.getJSON('http://127.0.0.1:8000/api/playgrounds_kidsle_geojson/', function(data) {
+			json_kidsle_corrected = data;
+		});
+
+		var json_playgrounds_clean = "";
+		$.getJSON('http://127.0.0.1:8000/api/playgrounds_clean/', function(data) {
+			json_playgrounds_clean = data;
+		});
+
+
+		// Workarround: after one second, the response "json_kidsle_corrected" and "json_playgrounds_clean" is complete
+		alert("please wait one second, and click OK");
+  
+    var myCenter = new L.LatLng(51.3254938,12.3754144);
+    var map = new L.Map('map', {center: myCenter, zoom: 12});
+
+	var schemes = [
+		'normal.day',
+		'normal.day.grey',
+		'normal.day.transit',
+		'normal.night.transit',
+// 		'normal.traffic.day',
+// 		'normal.traffic.night',
+		'normal.day.custom',
+		'normal.night',
+		'normal.night.grey',
+		'pedestrian.day',
+		'pedestrian.day.mobile',
+		'pedestrian.night',
+		'pedestrian.night.mobile',
+		'carnav.day.grey',
+		'normal.day.mobile',
+		'normal.day.grey.mobile',
+		'normal.day.transit.mobile',
+		'normal.night.transit.mobile',
+		'normal.night.mobile',
+		'normal.night.grey.mobile',
+		'reduced.day',
+		'reduced.night',
+		'terrain.day',
+		'satellite.day',
+		'hybrid.day',
+		'hybrid.day.transit',
+		'hybrid.grey.day',
+// 		'hybrid.traffic.day',
+		'terrain.day.mobile',
+		'hybrid.day.mobile'
+	]
+
+	var baselayers = {};
+
+	for (var i in schemes) {
+		var scheme = schemes[i];
+		baselayers[scheme] = L.tileLayer.here({
+			appId: '------------------------------------',
+			appCode: '------------------------------------',
+			scheme: scheme
+		});
+	}
+
+
+// 	baselayers['normal.day'].addTo(map);
+
+	L.control.layers(baselayers, {}, {collapsed: false}).addTo(map)
+
+	function onEachFeature(feature, layer) {
+			var popupContent = "<p>playgrounds</p>" +
+					"<p>id: "+feature.id + "</p>"+
+					"<p>lat: "+feature.geometry.coordinates[0] + "</p>"+
+					"<p>lon: "+feature.geometry.coordinates[1] + "</p>"+
+					"<p>properties: "+JSON.stringify(feature.properties) + "</p>";
+					//feature.geometry.type
+
+			if (feature.properties && feature.properties.popupContent) {
+				popupContent += feature.properties.popupContent;
+			}
+
+			layer.bindPopup(popupContent);
+		}
+
+		L.geoJson([json_kidsle_corrected], {
+
+			style: function (feature) {
+				return feature.properties && feature.properties.style;
+			},
+
+			onEachFeature: onEachFeature,
+
+			pointToLayer: function (feature, latlng) {
+				return L.circleMarker(latlng, {
+					radius: 8,
+					fillColor: "#ff7800",
+					color: "#000",
+					weight: 1,
+					opacity: 1,
+					fillOpacity: 0.8
+				});
+			}
+		}).addTo(map);
+
+		L.geoJson([json_playgrounds_clean], {
+
+			style: function (feature) {
+				return feature.properties && feature.properties.style;
+			},
+
+			onEachFeature: onEachFeature,
+
+			pointToLayer: function (feature, latlng) {
+				return L.circleMarker(latlng, {
+					radius: 8,
+					fillColor: "#007800",
+					color: "#000",
+					weight: 1,
+					opacity: 1,
+					fillOpacity: 0.8
+				});
+			}
+		}).addTo(map);
+
+
+
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
**changes:**
_index.ts_ -> added cors (necessary to consume the api) and access to (playgrounds_kidsle_spreadsheet.geojson)

_playgrounds_kidsle_spreadsheet.geojson_ -> internal manual corrected json file(playgrounds_from_kidsle.json) converted to geojson by http://www.convertcsv.com/csv-to-geojson.htm

_Leaflet.TileLayer.HERE.html_ -> Frontend

**how to use:**
1) start the project (npm install -> tsc -> node index.js)
2) start the frontend (utils/compare-geojson-frontend/Leaflet.TileLayer.HERE.html)
